### PR TITLE
Minimal socket and content support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,11 @@ You can also configure the port (with `-p`) and root directory (with
 ```bash
 java duckling.jar -p $(YOUR_FAVORITE_PORT) -d $(YOUR_FAVORITE_DIR)
 ```
+
+## A small overview
+
+Right now Duckling doesn't support routing at all.  It will display some HTML as expected, provide a small navigable directory listing, and respond with a 404 to missing content.
+
+## Known bugs
+
+* Deep traversal of directories is currently not supported.  This is getting punted on as of release 0.0.1 in the interests of getting a more thoroughly tested `FolderContents` and usable responder in play, vs. upgrading the current one further (which is moot, because it's serving its purpose as-is).

--- a/src/main/java/duckling/Configuration.java
+++ b/src/main/java/duckling/Configuration.java
@@ -1,5 +1,7 @@
 package duckling;
 
+import duckling.errors.BadArgumentsError;
+
 import java.util.Arrays;
 
 public class Configuration {

--- a/src/main/java/duckling/Main.java
+++ b/src/main/java/duckling/Main.java
@@ -1,31 +1,32 @@
 package duckling;
 
+import duckling.errors.BadArgumentsError;
+
+import java.io.IOException;
+import java.util.stream.Stream;
+
 public class Main {
+
     private Configuration config;
     private Server server;
 
-    public Main(Configuration config) {
+    public Main(Configuration config) throws IOException {
         this.config = config;
-        this.server = new Server(config.port);
+        this.server = new Server(config.port, config.root);
     }
 
-    public void start() {
-        beforeListen();
+    public void start() throws IOException {
+        Stream<String> output = Stream.of(
+            String.format("Port: %s", this.config.port),
+            String.format("Root: %s", this.config.root)
+        );
+
+        output.forEach(System.out::println);
+
         this.server.listen();
     }
 
-    private void beforeListen() {
-        String[] output = {
-                String.format("Port: %s", this.config.port),
-                String.format("Root: %s", this.config.root)
-        };
-
-        for (String line: output) {
-            System.out.println(line);
-        }
-    }
-
-    public static void main(String[] arguments) {
+    public static void main(String[] arguments) throws IOException {
         try {
             Configuration config = new Configuration(arguments);
             Main main = new Main(config);

--- a/src/main/java/duckling/ResponseHeaders.java
+++ b/src/main/java/duckling/ResponseHeaders.java
@@ -1,0 +1,37 @@
+package duckling;
+
+public class ResponseHeaders {
+    protected String contentType = "null";
+    protected String status = "200 OK";
+
+    public String[] toArray() {
+        return new String[] {
+            "HTTP/1.0 " + status + Server.CLRF,
+            "Content-Type: " + contentType + Server.CLRF,
+            Server.CLRF
+        };
+    }
+
+    public ResponseHeaders notFound() {
+        return withStatus("404 NOT FOUND");
+    }
+
+    public ResponseHeaders withContentType(String givenContentType) {
+        String currentStatus = status;
+
+        return new ResponseHeaders() {{
+            status = currentStatus;
+            contentType = givenContentType;
+        }};
+    }
+
+    public ResponseHeaders withStatus(String newStatus) {
+        String currentContentType = contentType;
+
+        return new ResponseHeaders() {{
+            status = newStatus;
+            contentType = currentContentType;
+        }};
+
+    }
+}

--- a/src/main/java/duckling/Server.java
+++ b/src/main/java/duckling/Server.java
@@ -1,11 +1,101 @@
 package duckling;
 
-public class Server {
-    public int port;
+import duckling.requests.Request;
+import duckling.requests.RequestBuilder;
+import duckling.responders.Responders;
 
-    public Server(int port) {
-        this.port = port;
+import java.io.*;
+import java.net.*;
+import java.util.concurrent.*;
+
+public class Server {
+    public static final String CLRF = "\r\n";
+
+    public int port;
+    public String root;
+
+    private boolean shuttingDown = false;
+    private InetSocketAddress address;
+    private ServerSocket connection;
+    private ExecutorService pool;
+
+    public Server(int port, String root) throws IOException {
+        this(
+            port,
+            root,
+            new ServerSocket(),
+            Executors.newCachedThreadPool()
+        );
     }
 
-    public void listen() {}
+    public Server(
+        int port,
+        String root,
+        ServerSocket connection,
+        ExecutorService pool
+    ) throws IOException {
+        this.port = port;
+        this.root = root;
+
+        this.address = new InetSocketAddress(this.port);
+        this.connection = connection;
+        this.pool = pool;
+    }
+
+    public boolean isPoolClosed() {
+        return this.pool.isShutdown();
+    }
+
+    public void onBegin() throws IOException {
+        this.connection.bind(this.address);
+    }
+
+    public void onRequest() throws IOException {
+        Socket client = this.connection.accept();
+        Runnable handler = () -> {
+            try {
+                RequestBuilder builder = new RequestBuilder(
+                    this.root,
+                    client.getInputStream()
+                );
+                Request request = builder.build();
+                Responders responders = new Responders(
+                    request,
+                    client.getOutputStream()
+                );
+
+                builder.printRawRequest();
+                responders.getResponder().respond();
+
+                client.close();
+            } catch (IOException exception) {
+                exception.printStackTrace();
+            }
+        };
+
+        this.pool.execute(handler);
+    }
+
+    public void onShutdown() {
+        try {
+            this.pool.shutdown();
+            this.connection.close();
+            this.shuttingDown = true;
+
+            System.out.println(CLRF + "Shutting down.");
+        } catch (IOException exception) {
+            exception.printStackTrace();
+        }
+    }
+
+    public void listen() throws IOException {
+        onBegin();
+
+        Runnable shutdown = this::onShutdown;
+        Runtime.getRuntime().addShutdownHook(new Thread(shutdown));
+
+        while(notShuttingDown()) onRequest();
+    }
+
+    private boolean notShuttingDown() { return !this.shuttingDown; }
 }

--- a/src/main/java/duckling/errors/BadArgumentsError.java
+++ b/src/main/java/duckling/errors/BadArgumentsError.java
@@ -1,4 +1,4 @@
-package duckling;
+package duckling.errors;
 
 public class BadArgumentsError extends Exception {
     public BadArgumentsError() {}

--- a/src/main/java/duckling/requests/InitialRequest.java
+++ b/src/main/java/duckling/requests/InitialRequest.java
@@ -1,0 +1,34 @@
+package duckling.requests;
+
+public class InitialRequest {
+    private String method, path, protocol;
+
+    public InitialRequest(String initialRequest) {
+        String[] tokens = initialRequest.split(" ");
+
+        try {
+            method = tokens[0];
+            path = tokens[1];
+            protocol = tokens[2];
+        } catch (ArrayIndexOutOfBoundsException exception) {
+        }
+    }
+
+    public String getMethod() {
+        return method;
+    }
+
+    public String getPath() {
+        return path;
+    }
+
+    public String getProtocol() {
+        return protocol;
+    }
+
+    public boolean equals(InitialRequest other) {
+        return method.equals(other.method)
+                && path.equals(other.path)
+                && protocol.equals(other.protocol);
+    }
+}

--- a/src/main/java/duckling/requests/Request.java
+++ b/src/main/java/duckling/requests/Request.java
@@ -1,0 +1,104 @@
+package duckling.requests;
+
+import duckling.Server;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Hashtable;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class Request {
+    protected boolean acceptingBody = false;
+    protected InitialRequest initialRequest;
+    protected Hashtable<String, String> headers = new Hashtable<>();
+    protected ArrayList<String> body = new ArrayList<>();
+    private String root;
+
+    public Request(String root) {
+        this.root = root;
+    }
+
+    public Request() {
+        this(".");
+    }
+
+    public String getBody() {
+        return body.stream().collect(Collectors.joining(Server.CLRF));
+    }
+
+    public String getHeader(String key) {
+        return headers.get(key);
+    }
+
+    public boolean isAcceptingBody() {
+        return acceptingBody;
+    }
+
+    public void setAcceptingBody() {
+        this.acceptingBody = true;
+    }
+
+    public void add(String line) {
+        if (line.length() == 0) setAcceptingBody();
+        if (this.initialRequest == null && !acceptingBody) setInitialRequest(line);
+
+        if (acceptingBody && line.length() != 0) {
+            body.add(line);
+        } else {
+            setHeaderPair(line);
+        }
+    }
+
+    private void setHeaderPair(String line) {
+        String[] headerPair = line.split(": ");
+
+        try {
+            headers.put(headerPair[0], headerPair[1]);
+        } catch (ArrayIndexOutOfBoundsException exception) {
+        }
+    }
+
+    private void setInitialRequest(String initialRequest) {
+        this.initialRequest = new InitialRequest(initialRequest);
+    }
+
+    public String initialRequestString() {
+        return Stream.of(
+            initialRequest.getMethod(),
+            initialRequest.getPath(),
+            initialRequest.getProtocol()
+        ).collect(Collectors.joining(" "));
+    }
+
+    public String getMethod() {
+        return initialRequest.getMethod();
+    }
+
+    public String getPath() {
+        return initialRequest.getPath();
+    }
+
+    public String getProtocol() {
+        return initialRequest.getProtocol();
+    }
+
+    public File getFile() {
+        return new File(fullFilePath());
+    }
+
+    public String fullFilePath() {
+        return root + getPath();
+    }
+
+    public boolean equals(Request other) {
+        return initialRequest.equals(other.initialRequest)
+                && body.equals(other.body)
+                && headers.equals(other.headers);
+    }
+
+    public String getRoot() {
+        return root;
+    }
+
+}

--- a/src/main/java/duckling/requests/RequestBuilder.java
+++ b/src/main/java/duckling/requests/RequestBuilder.java
@@ -1,0 +1,41 @@
+package duckling.requests;
+
+import duckling.Server;
+import duckling.requests.Request;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.stream.Stream;
+
+public class RequestBuilder {
+    private String root;
+    private String[] rawRequest;
+
+    public RequestBuilder(InputStream inputStream) throws IOException {
+        this(".", inputStream);
+    }
+
+    public RequestBuilder(String root, InputStream inputStream) throws IOException {
+        int input;
+        this.root = root;
+        StringBuilder requestBody = new StringBuilder();
+
+        while ((input = inputStream.read()) != -1 && inputStream.available() > 0) {
+            requestBody.append((char) input);
+        }
+
+        rawRequest = requestBody.toString().split(Server.CLRF);
+    }
+
+    public void printRawRequest() {
+        for (String line: rawRequest) System.out.println(line);
+    }
+
+    public Request build() {
+        Request request = new Request(root);
+
+        Stream.of(rawRequest).forEach(request::add);
+
+        return request;
+    }
+}

--- a/src/main/java/duckling/responders/FileContents.java
+++ b/src/main/java/duckling/responders/FileContents.java
@@ -1,0 +1,56 @@
+package duckling.responders;
+
+import duckling.requests.Request;
+import duckling.ResponseHeaders;
+
+import java.io.*;
+
+import static java.net.URLConnection.guessContentTypeFromName;
+import static java.net.URLConnection.guessContentTypeFromStream;
+
+public class FileContents extends Responder {
+    private File file;
+
+    public FileContents(Request request, OutputStream outputStream) {
+        super(request, outputStream);
+
+        this.file = request.getFile();
+    }
+
+    @Override
+    public boolean matches() {
+        return this.file.exists() && !this.file.isDirectory();
+    }
+
+    @Override
+    public void respond() throws IOException {
+        int bytes;
+
+        byte[] buffer = new byte[1024];
+        FileInputStream fileInputStream = new FileInputStream(file.getAbsoluteFile());
+        ResponseHeaders responseHeaders = new ResponseHeaders().
+                withContentType(getContentType());
+
+        for (String line: responseHeaders.toArray()) {
+            this.outputStream.write(line.getBytes());
+        }
+
+        while ((bytes = fileInputStream.read(buffer)) != -1) {
+            this.outputStream.write(buffer, 0, bytes);
+        }
+    }
+
+    private String getContentType() throws IOException {
+        String fromName = guessContentTypeFromName(file.getName());
+
+        if (fromName == null) {
+            InputStream buffer = new BufferedInputStream(
+                    new FileInputStream(file)
+            );
+
+            return guessContentTypeFromStream(buffer);
+        } else {
+            return fromName;
+        }
+    }
+}

--- a/src/main/java/duckling/responders/FolderContents.java
+++ b/src/main/java/duckling/responders/FolderContents.java
@@ -1,0 +1,62 @@
+package duckling.responders;
+
+import duckling.requests.Request;
+import duckling.ResponseHeaders;
+import duckling.Server;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.OutputStream;
+
+public class FolderContents extends Responder {
+    private File directory;
+
+    public FolderContents(Request request, OutputStream outputStream) {
+        super(request, outputStream);
+
+        this.directory = request.getFile();
+    }
+
+    @Override
+    public boolean matches() {
+        return this.directory.exists() && this.directory.isDirectory();
+    }
+
+    @Override
+    public void respond() throws IOException {
+        ResponseHeaders responseHeaders = new ResponseHeaders().
+                withContentType("text/html");
+
+        for (String line: responseHeaders.toArray()) {
+            this.outputStream.write(line.getBytes());
+        }
+
+        this.outputStream.write(rawFolderResponse().getBytes());
+    }
+
+    private String rawFolderResponse() {
+        return "<html><head><title>/"
+            + this.directory.getName()
+            + "</title></head><body>"
+            + contents()
+            + "</body></head>" + Server.CLRF;
+    }
+
+    private String contents() {
+        String links = "";
+        String[] list = this.directory.list();
+
+        for (String item: list) {
+            File file = new File(item);
+
+            if (file.isDirectory()) {
+                links = links + "<a href=\"/" + item + "/\">" + item + "/</a><br>";
+            } else {
+                links = links + "<a href=\"/" + item + "\">" + item + "</a><br>";
+            }
+        }
+
+        return links;
+    }
+
+}

--- a/src/main/java/duckling/responders/NotFound.java
+++ b/src/main/java/duckling/responders/NotFound.java
@@ -1,0 +1,39 @@
+package duckling.responders;
+
+import duckling.requests.Request;
+import duckling.ResponseHeaders;
+import duckling.Server;
+
+import java.io.OutputStream;
+import java.io.IOException;
+
+public class NotFound extends Responder {
+    public NotFound(Request request, OutputStream outputStream) {
+        super(request, outputStream);
+    }
+
+    @Override
+    public boolean matches() {
+        return true;
+    }
+
+    @Override
+    public void respond() throws IOException {
+        ResponseHeaders responseHeaders = new ResponseHeaders().
+                notFound().
+                withContentType("text/html");
+
+        for (String line: responseHeaders.toArray()) {
+            this.outputStream.write(line.getBytes());
+        }
+
+        this.outputStream.write(rawResponse().getBytes());
+    }
+
+    private String rawResponse() {
+       return "<html><head><title>Not found</title></head>" +
+           "<body>404 not found</body></head>" +
+           Server.CLRF;
+    }
+
+}

--- a/src/main/java/duckling/responders/Responder.java
+++ b/src/main/java/duckling/responders/Responder.java
@@ -1,0 +1,19 @@
+package duckling.responders;
+
+import duckling.requests.Request;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+public abstract class Responder {
+    protected Request request;
+    protected OutputStream outputStream;
+
+    public Responder(Request request, OutputStream outputStream) {
+        this.request = request;
+        this.outputStream = outputStream;
+    }
+
+    abstract public boolean matches();
+    abstract public void respond() throws IOException;
+}

--- a/src/main/java/duckling/responders/Responders.java
+++ b/src/main/java/duckling/responders/Responders.java
@@ -1,0 +1,45 @@
+package duckling.responders;
+
+import duckling.requests.Request;
+
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+public class Responders {
+    private Request request;
+    private OutputStream outputStream;
+    private ArrayList<Responder> responders;
+
+    public Responders(Request request, OutputStream outputStream) {
+        this(
+                request,
+            outputStream,
+            new FileContents(request, outputStream),
+            new FolderContents(request, outputStream),
+            new NotFound(request, outputStream)
+        );
+    }
+
+    public Responders(Request request, OutputStream outputStream, Responder... responders) {
+        ArrayList<Responder> list = new ArrayList<>();
+        Collections.addAll(list, responders);
+
+        this.request = request;
+        this.outputStream = outputStream;
+        this.responders = list;
+    }
+
+    public Responder getResponder() {
+        Stream<Responder> candidates = responders.stream().filter(Responder::matches);
+        Optional<Responder> candidate = candidates.findFirst();
+
+        if (candidate.isPresent()) {
+            return candidate.get();
+        } else {
+            return new NotFound(request, outputStream);
+        }
+    }
+}

--- a/src/test/java/duckling/ConfigurationTest.java
+++ b/src/test/java/duckling/ConfigurationTest.java
@@ -1,7 +1,9 @@
-import static org.junit.Assert.assertEquals;
-import org.junit.Test;
+package duckling;
 
-import duckling.Configuration;
+import static org.junit.Assert.assertEquals;
+
+import duckling.errors.BadArgumentsError;
+import org.junit.Test;
 
 public class ConfigurationTest {
     @Test
@@ -21,7 +23,7 @@ public class ConfigurationTest {
         assertEquals(config.root, "/var/www/duckling/public");
     }
 
-    @Test(expected = duckling.BadArgumentsError.class)
+    @Test(expected = BadArgumentsError.class)
     public void withNoRoot() throws Exception {
         String[] arguments = {"-d"};
         Configuration config = new Configuration(arguments);
@@ -43,13 +45,13 @@ public class ConfigurationTest {
         assertEquals(config.port, 80);
     }
 
-    @Test(expected = duckling.BadArgumentsError.class)
+    @Test(expected = BadArgumentsError.class)
     public void withNoPort() throws Exception {
         String[] arguments = {"-p"};
         Configuration config = new Configuration(arguments);
     }
 
-    @Test(expected = duckling.BadArgumentsError.class)
+    @Test(expected = BadArgumentsError.class)
     public void withMalformedPort() throws Exception {
         String[] arguments = {"-p", "unparseable"};
         Configuration config = new Configuration(arguments);

--- a/src/test/java/duckling/ResponseHeaderTest.java
+++ b/src/test/java/duckling/ResponseHeaderTest.java
@@ -1,0 +1,58 @@
+package duckling;
+
+import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+
+public class ResponseHeaderTest {
+    @Test
+    public void hasDefaultResponse() throws Exception {
+        ResponseHeaders responseHeaders = new ResponseHeaders();
+        String[] expectation = {
+            "HTTP/1.0 200 OK" + Server.CLRF,
+            "Content-Type: null" + Server.CLRF,
+            Server.CLRF
+        };
+        assertEquals(expectation, responseHeaders.toArray());
+    }
+
+    @Test
+    public void allowsCustomContentType() throws Exception {
+        ResponseHeaders responseHeaders = new ResponseHeaders().
+                withContentType("text/html");
+
+        String[] expectation = {
+                "HTTP/1.0 200 OK" + Server.CLRF,
+                "Content-Type: text/html" + Server.CLRF,
+                Server.CLRF
+        };
+
+        assertEquals(expectation, responseHeaders.toArray());
+    }
+
+    @Test
+    public void supports400NotFound() throws Exception {
+        ResponseHeaders responseHeaders = new ResponseHeaders().notFound();
+
+        String[] expectation = {
+                "HTTP/1.0 404 NOT FOUND" + Server.CLRF,
+                "Content-Type: null" + Server.CLRF,
+                Server.CLRF
+        };
+
+        assertEquals(expectation, responseHeaders.toArray());
+    }
+
+    @Test
+    public void supportsMethodChaining() throws Exception {
+        ResponseHeaders responseHeaders = new ResponseHeaders().
+                notFound().withContentType("text/html");
+
+        String[] expectation = {
+                "HTTP/1.0 404 NOT FOUND" + Server.CLRF,
+                "Content-Type: text/html" + Server.CLRF,
+                Server.CLRF
+        };
+
+        assertEquals(expectation, responseHeaders.toArray());
+    }
+}

--- a/src/test/java/duckling/ServerTest.java
+++ b/src/test/java/duckling/ServerTest.java
@@ -1,21 +1,59 @@
+package duckling;
+
 import static org.junit.Assert.assertEquals;
 
+import duckling.support.MockServerSocket;
+import duckling.support.MockThreadPool;
 import org.junit.Before;
 import org.junit.Test;
 
-import duckling.Server;
-
 public class ServerTest {
-    private int port = 5123, timeout = 100000;
+    private int port = 5123;
+    private String root = "./";
     private Server server;
+    private MockServerSocket connection;
+    private MockThreadPool pool;
 
     @Before
     public void setup() throws Exception {
-        server = new Server(port);
+        connection = new MockServerSocket();
+        pool = new MockThreadPool();
+        server = new Server(port, root, connection, pool);
     }
 
     @Test
     public void definePort() throws Exception {
         assertEquals(port, server.port);
     }
+
+    @Test
+    public void defineRoot() throws Exception {
+        assertEquals(root, server.root);
+    }
+
+    @Test
+    public void beforeListenBindsConnection() throws Exception {
+        server.onBegin();
+        assertEquals(true, connection.isBound());
+    }
+
+    @Test
+    public void onShutdownClosesConnection() throws Exception {
+        server.onBegin();
+        server.onShutdown();
+        assertEquals(true, connection.isClosed());
+    }
+
+    @Test
+    public void onShutdownClosesPool() throws Exception {
+        server.onShutdown();
+        assertEquals(true, server.isPoolClosed());
+    }
+
+    @Test
+    public void onSocketRequestLaunchesThread() throws Exception {
+        server.onRequest();
+        assertEquals(1, pool.getThreadCount());
+    }
+
 }

--- a/src/test/java/duckling/requests/InitialRequestTest.java
+++ b/src/test/java/duckling/requests/InitialRequestTest.java
@@ -1,0 +1,46 @@
+package duckling.requests;
+
+import duckling.requests.InitialRequest;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class InitialRequestTest {
+    private String rawInitialRequest;
+    private InitialRequest initialRequest;
+
+    @Before
+    public void setup() throws Exception {
+        rawInitialRequest = "GET / HTTP/1.1";
+        initialRequest = new InitialRequest(rawInitialRequest);
+    }
+
+    @Test
+    public void setsThePath() throws Exception {
+        assertEquals("/", initialRequest.getPath());
+    }
+
+    @Test
+    public void setsTheProtocol() throws Exception {
+        assertEquals("HTTP/1.1", initialRequest.getProtocol());
+    }
+
+    @Test
+    public void setsTheMethod() throws Exception {
+        assertEquals("GET", initialRequest.getMethod());
+    }
+
+    @Test
+    public void matchesSimilarInitialRequests() throws Exception {
+        InitialRequest otherRequest = new InitialRequest(rawInitialRequest);
+        assertEquals(true, initialRequest.equals(otherRequest));
+    }
+
+    @Test
+    public void doesNotMatchDissimilarInitialRequests() throws Exception {
+        InitialRequest otherRequest = new InitialRequest("POST / HTTP/1.1");
+        assertEquals(false, initialRequest.equals(otherRequest));
+    }
+
+}

--- a/src/test/java/duckling/requests/RequestBuilderTest.java
+++ b/src/test/java/duckling/requests/RequestBuilderTest.java
@@ -1,0 +1,42 @@
+package duckling.requests;
+
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+
+import static org.junit.Assert.assertEquals;
+
+
+public class RequestBuilderTest {
+
+    @Test
+    public void withRoot() throws Exception {
+        byte[] getRequest = "GET / HTTP/1.1\r\n\r\n".getBytes();
+        String root = "/some/directory/path";
+        InputStream requestContents = new ByteArrayInputStream(getRequest);
+        RequestBuilder builder = new RequestBuilder(root, requestContents);
+        Request request = new Request(root);
+
+        assertEquals(request.getRoot(), builder.build().getRoot());
+    }
+
+    @Test
+    public void withoutRoot() throws Exception {
+        Request request = new Request();
+        assertEquals(".", request.getRoot());
+    }
+
+
+    @Test
+    public void fromInputStream() throws Exception {
+        byte[] getRequest = "GET / HTTP/1.1\r\n\r\n".getBytes();
+        InputStream requestContents = new ByteArrayInputStream(getRequest);
+        RequestBuilder builder = new RequestBuilder(requestContents);
+        Request request = new Request();
+
+        request.add("GET / HTTP/1.1");
+
+        assertEquals(true, request.equals(builder.build()));
+    }
+}

--- a/src/test/java/duckling/requests/RequestTest.java
+++ b/src/test/java/duckling/requests/RequestTest.java
@@ -1,0 +1,113 @@
+package duckling.requests;
+
+import static org.junit.Assert.assertEquals;
+
+import duckling.Server;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+
+public class RequestTest {
+    private Request request;
+
+    @Before
+    public void setup() throws Exception {
+        request = new Request();
+    }
+
+    @Test
+    public void withRoot() throws Exception {
+        String root = "/some/directory/path";
+        Request request = new Request(root);
+        assertEquals(root, request.getRoot());
+    }
+
+    @Test
+    public void withoutRoot() throws Exception {
+        Request request = new Request();
+        assertEquals(".", request.getRoot());
+    }
+
+    @Test
+    public void buildsFilePath() throws Exception {
+        String root = "/some/directory/path";
+        Request request = new Request(root);
+        request.add("GET /crazy.html HTTP/1.1");
+        assertEquals(root + "/crazy.html", request.fullFilePath());
+
+    }
+
+    @Test
+    public void similarTokensAreEquivalent() throws Exception {
+        Request otherTokens = new Request();
+        request.add("GET / HTTP/1.1");
+        otherTokens.add("GET / HTTP/1.1");
+        assertEquals(true, request.equals(otherTokens));
+    }
+
+    @Test
+    public void dissimilarTokensAreNotEquivalent() throws Exception {
+        Request otherTokens = new Request();
+        request.add("GET / HTTP/1.1");
+        otherTokens.add("GET / HTTP/1.0");
+        assertEquals(false, request.equals(otherTokens));
+    }
+
+
+    @Test
+    public void firstLineIsInitialRequest() throws Exception {
+        request.add("GET / HTTP/1.1");
+        assertEquals(request.initialRequestString(), "GET / HTTP/1.1");
+    }
+
+    @Test
+    public void tokenizesInitialRequestMethod() throws Exception {
+        request.add("GET / HTTP/1.1");
+        assertEquals(request.getMethod(), "GET");
+    }
+
+    @Test
+    public void tokenizesInitialRequestPath() throws Exception {
+        request.add("GET / HTTP/1.1");
+        assertEquals(request.getPath(), "/");
+    }
+
+    @Test
+    public void providesPathFileReference() throws Exception {
+        request.add("GET / HTTP/1.1");
+        assertEquals(request.getFile(), new File("./"));
+    }
+
+    @Test
+    public void tokenizesInitialRequestProtocol() throws Exception {
+        request.add("GET / HTTP/1.1");
+        assertEquals(request.getProtocol(), "HTTP/1.1");
+    }
+
+    @Test
+    public void additionalLinesAreHeaders() throws Exception {
+        request.add("GET / HTTP/1.1");
+        request.add("Host: localhost");
+        assertEquals(request.getHeader("Host"), "localhost");
+    }
+
+    @Test
+    public void setAcceptingBody() throws Exception {
+        request.setAcceptingBody();
+        assertEquals(true, request.isAcceptingBody());
+    }
+
+    @Test
+    public void bodyFollowsAnEmptyLine() throws Exception {
+        request.add("GET / HTTP/1.1");
+        request.add("");
+        request.add("Body line one");
+        request.add("Body line two");
+        Assert.assertEquals(
+            request.getBody(),
+            "Body line one" + Server.CLRF + "Body line two"
+        );
+    }
+}

--- a/src/test/java/duckling/responders/RespondersTest.java
+++ b/src/test/java/duckling/responders/RespondersTest.java
@@ -1,0 +1,75 @@
+package duckling.responders;
+
+import static org.junit.Assert.assertEquals;
+
+import duckling.requests.Request;
+import duckling.requests.RequestBuilder;
+import duckling.responders.Responder;
+import duckling.responders.Responders;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+public class RespondersTest {
+    private OutputStream outputStream;
+    private Request request;
+
+    @Before
+    public void setup() throws Exception {
+        InputStream inputStream = new InputStream() {
+            @Override
+            public int read() throws IOException {
+                return 0;
+            }
+        };
+
+        this.outputStream = new OutputStream() {
+            @Override
+            public void write(int b) throws IOException { }
+        };
+
+        this.request = new RequestBuilder(inputStream).build();
+    }
+
+    @Test
+    public void getResponderReturnsFirstMatch() throws IOException {
+        Responders responders = new Responders(
+            this.request,
+            this.outputStream,
+            new NoMatchResponder(this.request, this.outputStream),
+            new MatchResponder(this.request, this.outputStream)
+        );
+
+        assertEquals(
+            MatchResponder.class,
+            responders.getResponder().getClass()
+        );
+    }
+
+    private class MatchResponder extends Responder {
+        MatchResponder(Request request, OutputStream outputStream) {
+            super(request, outputStream);
+        }
+
+        @Override
+        public boolean matches() { return true; }
+
+        @Override
+        public void respond() throws IOException { }
+    }
+
+    private class NoMatchResponder extends Responder {
+        NoMatchResponder(Request request, OutputStream outputStream) {
+            super(request, outputStream);
+        }
+
+        @Override
+        public boolean matches() { return false; }
+
+        @Override
+        public void respond() throws IOException { }
+    }
+}

--- a/src/test/java/duckling/support/MockServerSocket.java
+++ b/src/test/java/duckling/support/MockServerSocket.java
@@ -1,0 +1,39 @@
+package duckling.support;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.net.SocketAddress;
+
+public class MockServerSocket extends ServerSocket {
+    private boolean isBound = false;
+
+    public MockServerSocket() throws IOException {
+    }
+
+    @Override
+    public Socket accept() {
+        return new Socket();
+    }
+
+    @Override
+    public void bind(SocketAddress address) {
+        this.isBound = true;
+    }
+
+    @Override
+    public void close() {
+        this.isBound = false;
+    }
+
+    @Override
+    public boolean isBound() {
+        return this.isBound;
+    }
+
+    @Override
+    public boolean isClosed() {
+        return !this.isBound;
+    }
+
+}

--- a/src/test/java/duckling/support/MockThreadPool.java
+++ b/src/test/java/duckling/support/MockThreadPool.java
@@ -1,0 +1,35 @@
+package duckling.support;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+public class MockThreadPool extends ThreadPoolExecutor {
+    private List<Runnable> threads = new ArrayList<>();
+
+    public MockThreadPool() {
+        this(1, 1, 1, TimeUnit.SECONDS, new SynchronousQueue<>());
+    }
+
+    public MockThreadPool(
+            int corePoolSize,
+            int maximumPoolSize,
+            long keepAliveTime,
+            TimeUnit unit,
+            BlockingQueue<Runnable> workQueue
+    ) {
+        super(corePoolSize, maximumPoolSize, keepAliveTime, unit, workQueue);
+    }
+
+    @Override
+    public void execute(Runnable runnable) {
+        this.threads.add(runnable);
+    }
+
+    public int getThreadCount() {
+        return this.threads.size();
+    }
+}


### PR DESCRIPTION
This is a pretty large commit (mea culpa) - but at least there's a
reasonable rationalization motivating it.  At its groundwork, we have a
few intertwined concepts, which we're representing here, but they all
have a central common link:

> We want to see a minimal response when browsing a remote public directory.

It followed that we needed at least basic support for understanding
socket input and output, as well as the ability to read directory
contents, individual file contents, and at least an informative response
if we hit something which wasn't there.

There's a few places in this house which need sweeping, but we're
punting on for the time being in the interests of publishing some new
code to master.  Most notably, we need better test coverage (and
probably better structure overall) to our concrete Responders.