### PR TITLE
Add gradle jar build script.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,20 @@ If you like your command line, here's a good one-liner (you might need to grab `
 wget https://github.com/esmevane/duckling/releases/download/v0.0.1/duckling.jar
 ```
 
+## Building
+
+If building the current master (or a given release) directly is more your speed, you'll need to have `gradle` installed.  Once you do, here's a snippet to get you going:
+
+```bash
+git clone git@github.com:esmevane/duckling.git
+cd duckling
+gradle jar
+```
+
+That snippet will grab this repository, install it in your `${pwd}/duckling`, hop into that directory, and then use the `gradle` build scripts to get a jar together.  It will deposit the jar in the root of the duckling directory, under `duckling.jar`.
+
+Enjoy!
+
 ## Usage
 
 Once you have your `duckling.jar`, you can run it with Java:

--- a/build.gradle
+++ b/build.gradle
@@ -9,12 +9,22 @@
 
 // Apply the java plugin to add support for Java
 apply plugin: 'java'
+version = '0.0.1'
 
 // In this section you declare where to find the dependencies of your project
 repositories {
     // Use 'jcenter' for resolving your dependencies.
     // You can declare any Maven/Ivy/file repository here.
     jcenter()
+}
+
+jar {
+    manifest {
+        attributes 'Main-Class': 'duckling.Main'
+    }
+
+    archiveName = 'duckling.jar'
+    destinationDir file('.')
 }
 
 // In this section you declare the dependencies for your production and test code


### PR DESCRIPTION
You can now make a custom build of duckling at any point by calling
`gradle jar` from within the project root.  The result is a version of
the jar built from whatever crazy point in the project history you might
be.