### PR TITLE
Fix CRLF typo.

### DIFF
--- a/src/main/java/duckling/ResponseHeaders.java
+++ b/src/main/java/duckling/ResponseHeaders.java
@@ -6,9 +6,9 @@ public class ResponseHeaders {
 
     public String[] toArray() {
         return new String[] {
-            "HTTP/1.0 " + status + Server.CLRF,
-            "Content-Type: " + contentType + Server.CLRF,
-            Server.CLRF
+            "HTTP/1.0 " + status + Server.CRLF,
+            "Content-Type: " + contentType + Server.CRLF,
+            Server.CRLF
         };
     }
 

--- a/src/main/java/duckling/Server.java
+++ b/src/main/java/duckling/Server.java
@@ -9,7 +9,7 @@ import java.net.*;
 import java.util.concurrent.*;
 
 public class Server {
-    public static final String CLRF = "\r\n";
+    public static final String CRLF = "\r\n";
 
     public int port;
     public String root;
@@ -82,7 +82,7 @@ public class Server {
             this.connection.close();
             this.shuttingDown = true;
 
-            System.out.println(CLRF + "Shutting down.");
+            System.out.println(CRLF + "Shutting down.");
         } catch (IOException exception) {
             exception.printStackTrace();
         }

--- a/src/main/java/duckling/requests/Request.java
+++ b/src/main/java/duckling/requests/Request.java
@@ -24,7 +24,7 @@ public class Request {
     }
 
     public String getBody() {
-        return body.stream().collect(Collectors.joining(Server.CLRF));
+        return body.stream().collect(Collectors.joining(Server.CRLF));
     }
 
     public String getHeader(String key) {

--- a/src/main/java/duckling/requests/RequestBuilder.java
+++ b/src/main/java/duckling/requests/RequestBuilder.java
@@ -1,7 +1,6 @@
 package duckling.requests;
 
 import duckling.Server;
-import duckling.requests.Request;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -24,7 +23,7 @@ public class RequestBuilder {
             requestBody.append((char) input);
         }
 
-        rawRequest = requestBody.toString().split(Server.CLRF);
+        rawRequest = requestBody.toString().split(Server.CRLF);
     }
 
     public void printRawRequest() {

--- a/src/main/java/duckling/responders/FolderContents.java
+++ b/src/main/java/duckling/responders/FolderContents.java
@@ -39,7 +39,7 @@ public class FolderContents extends Responder {
             + this.directory.getName()
             + "</title></head><body>"
             + contents()
-            + "</body></head>" + Server.CLRF;
+            + "</body></head>" + Server.CRLF;
     }
 
     private String contents() {

--- a/src/main/java/duckling/responders/NotFound.java
+++ b/src/main/java/duckling/responders/NotFound.java
@@ -33,7 +33,7 @@ public class NotFound extends Responder {
     private String rawResponse() {
        return "<html><head><title>Not found</title></head>" +
            "<body>404 not found</body></head>" +
-           Server.CLRF;
+           Server.CRLF;
     }
 
 }

--- a/src/main/java/duckling/responders/Responders.java
+++ b/src/main/java/duckling/responders/Responders.java
@@ -15,7 +15,7 @@ public class Responders {
 
     public Responders(Request request, OutputStream outputStream) {
         this(
-                request,
+            request,
             outputStream,
             new FileContents(request, outputStream),
             new FolderContents(request, outputStream),

--- a/src/test/java/duckling/ResponseHeaderTest.java
+++ b/src/test/java/duckling/ResponseHeaderTest.java
@@ -8,9 +8,9 @@ public class ResponseHeaderTest {
     public void hasDefaultResponse() throws Exception {
         ResponseHeaders responseHeaders = new ResponseHeaders();
         String[] expectation = {
-            "HTTP/1.0 200 OK" + Server.CLRF,
-            "Content-Type: null" + Server.CLRF,
-            Server.CLRF
+            "HTTP/1.0 200 OK" + Server.CRLF,
+            "Content-Type: null" + Server.CRLF,
+            Server.CRLF
         };
         assertEquals(expectation, responseHeaders.toArray());
     }
@@ -21,9 +21,9 @@ public class ResponseHeaderTest {
                 withContentType("text/html");
 
         String[] expectation = {
-                "HTTP/1.0 200 OK" + Server.CLRF,
-                "Content-Type: text/html" + Server.CLRF,
-                Server.CLRF
+                "HTTP/1.0 200 OK" + Server.CRLF,
+                "Content-Type: text/html" + Server.CRLF,
+                Server.CRLF
         };
 
         assertEquals(expectation, responseHeaders.toArray());
@@ -34,9 +34,9 @@ public class ResponseHeaderTest {
         ResponseHeaders responseHeaders = new ResponseHeaders().notFound();
 
         String[] expectation = {
-                "HTTP/1.0 404 NOT FOUND" + Server.CLRF,
-                "Content-Type: null" + Server.CLRF,
-                Server.CLRF
+                "HTTP/1.0 404 NOT FOUND" + Server.CRLF,
+                "Content-Type: null" + Server.CRLF,
+                Server.CRLF
         };
 
         assertEquals(expectation, responseHeaders.toArray());
@@ -48,9 +48,9 @@ public class ResponseHeaderTest {
                 notFound().withContentType("text/html");
 
         String[] expectation = {
-                "HTTP/1.0 404 NOT FOUND" + Server.CLRF,
-                "Content-Type: text/html" + Server.CLRF,
-                Server.CLRF
+                "HTTP/1.0 404 NOT FOUND" + Server.CRLF,
+                "Content-Type: text/html" + Server.CRLF,
+                Server.CRLF
         };
 
         assertEquals(expectation, responseHeaders.toArray());

--- a/src/test/java/duckling/requests/RequestTest.java
+++ b/src/test/java/duckling/requests/RequestTest.java
@@ -107,7 +107,7 @@ public class RequestTest {
         request.add("Body line two");
         Assert.assertEquals(
             request.getBody(),
-            "Body line one" + Server.CLRF + "Body line two"
+            "Body line one" + Server.CRLF + "Body line two"
         );
     }
 }


### PR DESCRIPTION
It's carriage-return-line-feed, not carriage-line-return-feed.  I do
this when I say the abbreviation out loud as well.