### PR TITLE
Add travis build status to README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/esmevane/duckling.svg?branch=master)](https://travis-ci.org/esmevane/duckling)
+
 # Duckling
 
 A petite Java http server, with the major goals of being enjoyable to read and well tested.  So named because the original author's son loves ducks (and also pigeons); it's not a Hans Christian Andersen reference, promise.


### PR DESCRIPTION
We want an at-a-glance badge on our README, for maximum shiny.