### PR TITLE
Add stage task for Heroku support.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,9 @@ repositories {
     jcenter()
 }
 
+task stage(dependsOn: ['build', 'clean'])
+build.mustRunAfter clean
+
 jar {
     manifest {
         attributes 'Main-Class': 'duckling.Main'


### PR DESCRIPTION
Heroku is kind of a big unknown here.  I can't imagine that the
directory listing, etc., will work - but it will be interesting to see
what happens.

This commit introduces a `stage` task to gradle, which is one of the
prerequisites for a Heroku deployment.  This deployment is currently set
to trigger immediately after a successful CI build on master.  In the
future that may change.