### PR TITLE
Declarative optionals, no handler logger noise.

### DIFF
--- a/src/main/java/duckling/requests/RequestHandler.java
+++ b/src/main/java/duckling/requests/RequestHandler.java
@@ -15,11 +15,17 @@ import java.util.ArrayList;
 public class RequestHandler implements Runnable {
     private final Configuration config;
     private final Socket client;
+    private final Logger logger;
     private ArrayList<String> loggables = new ArrayList<>();
 
     public RequestHandler(Socket client, Configuration config) {
+        this(client, config, new Logger());
+    }
+
+    public RequestHandler(Socket client, Configuration config, Logger logger) {
         this.client = client;
         this.config = config;
+        this.logger = logger;
     }
 
     @Override
@@ -28,7 +34,6 @@ public class RequestHandler implements Runnable {
             OutputStream output = this.client.getOutputStream();
             Request request = marshalRequest();
             Responder responder = getResponder(request);
-            Logger logger = getLogger();
 
             new HeadersWriter(responder, output).write();
             new BodyWriter(responder, output).write();
@@ -68,10 +73,6 @@ public class RequestHandler implements Runnable {
         Responders responders = new Responders(request, config);
 
         return responders.getResponder();
-    }
-
-    public Logger getLogger() {
-        return new Logger();
     }
 
 }

--- a/src/main/java/duckling/responders/DefinedContents.java
+++ b/src/main/java/duckling/responders/DefinedContents.java
@@ -14,7 +14,10 @@ import java.util.ArrayList;
 import java.util.Optional;
 
 public class DefinedContents extends Responder {
-    private RouteDefinitions routes;
+    private RouteDefinitions routes = new RouteDefinitions();
+    private String template =
+        "<html><head><title>%s</title></head>" +
+            "<body>%s</body></html>";
 
     public DefinedContents(Request request, Configuration config) {
         super(request, config);
@@ -24,48 +27,49 @@ public class DefinedContents extends Responder {
 
     @Override
     public boolean matches() {
-        if (routes == null) return false;
-
         return routes.hasRoute(request);
     }
 
     @Override
     public ArrayList<String> headers() throws IOException {
         Optional<Route> maybeRoute = routes.getMatch(request);
-        ResponseHeaders headers = new ResponseHeaders();
 
-        if (maybeRoute.isPresent()) {
-            Route route = maybeRoute.get();
-            return headers.
-                withStatus(route.getResponseCode()).
-                withContentType("text/html").
-                toList();
-        }
-
-        return headers.
-            withStatus(ResponseCode.notFound()).
-            toList();
+        return maybeRoute.
+            map(this::headersFromRoute).
+            orElseGet(this::buildHeaders);
     }
 
     @Override
     public InputStream body() throws IOException {
         Optional<Route> maybeRoute = routes.getMatch(request);
-        String template =
-            "<html><head><title>%s</title></head>" +
-                "<body>%s</body></html>";
+        String fileContent = maybeRoute.
+            map(route -> buildContent(request.getPath(), route.getContent())).
+            orElseGet(this::buildContent);
 
-        if (maybeRoute.isPresent()) {
-            Route route = maybeRoute.get();
-            String fileContent = String.format(
-                template,
-                request.getPath(),
-                route.getContent()
-            );
-
-            return new ByteArrayInputStream(fileContent.getBytes());
-        }
-
-        String fileContent = String.format(template, "", "");
         return new ByteArrayInputStream(fileContent.getBytes());
     }
+
+    private String buildContent() {
+        return buildContent("", "");
+    }
+
+    private String buildContent(String path, String content) {
+        return String.format(this.template, path, content);
+    }
+
+    private ArrayList<String> headersFromRoute(Route route) {
+        ResponseHeaders headers = new ResponseHeaders();
+
+        return headers.
+            withStatus(route.getResponseCode()).
+            withContentType("text/html").
+            toList();
+    }
+
+    private ArrayList<String> buildHeaders() {
+        ResponseHeaders headers = new ResponseHeaders();
+
+        return headers.withStatus(ResponseCode.notFound()).toList();
+    }
+
 }

--- a/src/main/java/duckling/responders/Responder.java
+++ b/src/main/java/duckling/responders/Responder.java
@@ -20,8 +20,6 @@ public abstract class Responder {
         this.request = request;
     }
 
-    ;
-
     abstract public boolean matches();
 
     abstract public ArrayList<String> headers() throws IOException;

--- a/src/test/java/duckling/requests/RequestHandlerTest.java
+++ b/src/test/java/duckling/requests/RequestHandlerTest.java
@@ -19,13 +19,15 @@ public class RequestHandlerTest {
     private String root;
     private Configuration config;
     private RequestHandler handler;
+    private SpyLogger logger;
 
     @Before
     public void setup() throws Exception {
         client = new SpySocket();
         root = "/path/to/root";
         config = new Configuration(5151, root);
-        handler = new RequestHandler(client, config);
+        logger = new SpyLogger();
+        handler = new RequestHandler(client, config, logger);
     }
 
     @Test
@@ -41,15 +43,9 @@ public class RequestHandlerTest {
 
     @Test
     public void runOutputsLogDetail() throws Exception {
-        SpyLogger spyLogger = new SpyLogger();
         String message = "GET / HTTP/1.1";
 
-        RequestHandler handler = new RequestHandler(client, config) {
-            @Override
-            public Logger getLogger() {
-                return spyLogger;
-            }
-
+        RequestHandler handler = new RequestHandler(client, config, logger) {
             @Override
             public RequestStream buildRequestStream() throws IOException {
                 return new RequestStream(client.getInputStream()) {
@@ -63,7 +59,7 @@ public class RequestHandlerTest {
 
         handler.run();
 
-        assertThat(spyLogger.messages, hasItem(message));
+        assertThat(logger.messages, hasItem(message));
     }
 
     @Test
@@ -84,15 +80,11 @@ public class RequestHandlerTest {
         };
 
         System.out.println("" + request.getPath());
-        RequestHandler handler = new RequestHandler(client, config) {
+
+        RequestHandler handler = new RequestHandler(client, config, logger) {
             @Override
             public Request prepareRequest() {
                 return request;
-            }
-
-            @Override
-            public Logger getLogger() {
-                return new SpyLogger();
             }
 
             @Override


### PR DESCRIPTION
This is a tidy-up commit, containing a bug fix and a refactoring:

* Optionals have been refactored to use their more functional /
  declarative interfaces, instead of the procedural options.  In other
  words, where we were gating unsafe optional operations behind a
  presence check, we're now simply telling the optional what it should
  do in any given case.
* RequestHandler was silently quacking its way through the test suite,
  throwing tons of invisibles into the test console.  This was silent
  quacking for some, noisy quacking for others.  In the test suite
  RequestHandler is now handed a SpyLogger, muting the quacking
  completely.