### PR TITLE
Omit bodies of HEAD requests.

### DIFF
--- a/src/main/java/duckling/Main.java
+++ b/src/main/java/duckling/Main.java
@@ -5,6 +5,7 @@ import duckling.errors.BadArgumentsError;
 import java.io.IOException;
 
 public class Main {
+    public static Logger LOGGER = new Logger();
 
     private Configuration config;
     private Server server;
@@ -13,7 +14,7 @@ public class Main {
     public Main(Configuration config) throws IOException {
         this.config = config;
         this.server = new Server(config);
-        this.logger = new Logger();
+        this.logger = LOGGER;
     }
 
     public void start() throws IOException {
@@ -36,7 +37,7 @@ public class Main {
 
             main.start();
         } catch (BadArgumentsError exception) {
-            System.out.println("Usage: -p <port> -d <root directory>");
+            LOGGER.info("Usage: -p <port> -d <root directory>");
         } finally {
             System.exit(1);
         }

--- a/src/main/java/duckling/responders/DefinedContents.java
+++ b/src/main/java/duckling/responders/DefinedContents.java
@@ -49,6 +49,11 @@ public class DefinedContents extends Responder {
         return new ByteArrayInputStream(fileContent.getBytes());
     }
 
+    @Override
+    public boolean isAllowed() {
+        return this.allowedMethods.contains(request.getMethod());
+    }
+
     private String buildContent() {
         return buildContent("", "");
     }

--- a/src/main/java/duckling/responders/FileContents.java
+++ b/src/main/java/duckling/responders/FileContents.java
@@ -37,7 +37,7 @@ public class FileContents extends Responder {
     public ArrayList<String> headers() throws IOException {
         ResponseHeaders headers = new ResponseHeaders();
 
-        if (methodNotAllowed()) return headers.notAllowed().toList();
+        if (!isAllowed()) return headers.notAllowed().toList();
 
         return headers.withContentType(getContentType()).toList();
     }
@@ -45,6 +45,11 @@ public class FileContents extends Responder {
     @Override
     public InputStream body() throws IOException {
         return getFileStream();
+    }
+
+    @Override
+    public boolean isAllowed() {
+        return this.allowedMethods.contains(request.getMethod());
     }
 
     private String getContentType() throws IOException {
@@ -65,10 +70,6 @@ public class FileContents extends Responder {
         } catch (FileNotFoundException exception) {
             return new ByteArrayInputStream("".getBytes());
         }
-    }
-
-    private boolean methodNotAllowed() {
-        return !request.getMethod().equals("GET");
     }
 
 }

--- a/src/main/java/duckling/responders/FolderContents.java
+++ b/src/main/java/duckling/responders/FolderContents.java
@@ -40,16 +40,21 @@ public class FolderContents extends Responder {
     public ArrayList<String> headers() throws IOException {
         ResponseHeaders headers = new ResponseHeaders();
 
-        if (methodNotAllowed()) return headers.notAllowed().toList();
+        if (!isAllowed()) return headers.notAllowed().toList();
 
         return headers.withContentType("text/html").toList();
     }
 
     @Override
     public InputStream body() throws IOException {
-        String responseContent = methodNotAllowed() ? "" : rawFolderResponse();
+        String responseContent = !isAllowed() ? "" : rawFolderResponse();
 
         return new ByteArrayInputStream(responseContent.getBytes());
+    }
+
+    @Override
+    public boolean isAllowed() {
+        return this.allowedMethods.contains(request.getMethod());
     }
 
     private String rawFolderResponse() {
@@ -69,10 +74,6 @@ public class FolderContents extends Responder {
         Stream<String> links = Stream.of(list).map(this::toLink);
 
         return links.collect(Collectors.joining());
-    }
-
-    private boolean methodNotAllowed() {
-        return !request.getMethod().equals("GET");
     }
 
     private String toLink(String item) {

--- a/src/main/java/duckling/responders/NotFound.java
+++ b/src/main/java/duckling/responders/NotFound.java
@@ -29,6 +29,11 @@ public class NotFound extends Responder {
         return new ByteArrayInputStream(rawResponse().getBytes());
     }
 
+    @Override
+    public boolean isAllowed() {
+        return true;
+    }
+
     private String rawResponse() {
         return "<html><head><title>Not found</title></head>" +
             "<body>404 not found</body></head>" +

--- a/src/main/java/duckling/responders/Responder.java
+++ b/src/main/java/duckling/responders/Responder.java
@@ -10,6 +10,13 @@ import java.util.ArrayList;
 public abstract class Responder {
     protected Request request;
     protected Configuration config;
+    protected ArrayList<String> allowedMethods = new ArrayList<>();
+
+    {
+        this.allowedMethods.add("GET");
+        this.allowedMethods.add("HEAD");
+        this.allowedMethods.add("OPTIONS");
+    }
 
     public Responder(Request request) {
         this(request, new Configuration());
@@ -25,5 +32,7 @@ public abstract class Responder {
     abstract public ArrayList<String> headers() throws IOException;
 
     abstract public InputStream body() throws IOException;
+
+    abstract public boolean isAllowed();
 
 }

--- a/src/main/java/duckling/responders/Responders.java
+++ b/src/main/java/duckling/responders/Responders.java
@@ -5,8 +5,6 @@ import duckling.requests.Request;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Optional;
-import java.util.stream.Stream;
 
 public class Responders {
     private Request request;
@@ -40,13 +38,11 @@ public class Responders {
     }
 
     public Responder getResponder() {
-        Stream<Responder> candidates = responders.stream().filter(Responder::matches);
-        Optional<Responder> candidate = candidates.findFirst();
-
-        if (candidate.isPresent()) {
-            return candidate.get();
-        } else {
-            return new NotFound(request);
-        }
+        return responders.
+            stream().
+            filter(Responder::matches).
+            findFirst().
+            map((Responder candidate) -> candidate).
+            orElseGet(() -> new NotFound(request));
     }
 }

--- a/src/main/java/duckling/routing/Routes.java
+++ b/src/main/java/duckling/routing/Routes.java
@@ -44,9 +44,6 @@ public class Routes {
     }
 
     public static Route fromRequest(Request request) {
-        if (request.getPath() == null) {
-            System.out.println(request.toString());
-        }
         return new Route(request.getMethod(), request.getPath());
     }
 

--- a/src/test/java/duckling/responders/RespondersTest.java
+++ b/src/test/java/duckling/responders/RespondersTest.java
@@ -71,6 +71,11 @@ public class RespondersTest {
         public InputStream body() throws IOException {
             return null;
         }
+
+        @Override
+        public boolean isAllowed() {
+            return true;
+        }
     }
 
     private class NoMatchResponder extends Responder {
@@ -91,6 +96,11 @@ public class RespondersTest {
         @Override
         public InputStream body() throws IOException {
             return null;
+        }
+
+        @Override
+        public boolean isAllowed() {
+            return true;
         }
     }
 }

--- a/src/test/java/duckling/support/SpyResponder.java
+++ b/src/test/java/duckling/support/SpyResponder.java
@@ -6,7 +6,6 @@ import duckling.responders.Responder;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
-import java.util.List;
 
 public class SpyResponder extends Responder {
     private boolean wereHeadersCalled = false;
@@ -61,5 +60,10 @@ public class SpyResponder extends Responder {
     public InputStream body() throws IOException {
         this.wasBodyCalled = true;
         return this.inputStream;
+    }
+
+    @Override
+    public boolean isAllowed() {
+        return true;
     }
 }


### PR DESCRIPTION
In the case that we get a HEAD request for any route, we don't want to
publish a body with our response.

Under the hood this is instrumented as part of a larger refactor, where
given responders will know what sort of requests they allow.  This paves
the way for request handling to get a little more in depth as time goes
on.