### PR TITLE
Support options requests.

### DIFF
--- a/src/main/java/duckling/requests/Request.java
+++ b/src/main/java/duckling/requests/Request.java
@@ -116,4 +116,7 @@ public class Request {
         }
     }
 
+    public boolean isOptions() {
+        return getMethod().equals("OPTIONS");
+    }
 }

--- a/src/main/java/duckling/responders/DefinedContents.java
+++ b/src/main/java/duckling/responders/DefinedContents.java
@@ -32,11 +32,16 @@ public class DefinedContents extends Responder {
 
     @Override
     public ArrayList<String> headers() throws IOException {
+        if (request.isOptions()) return optionsHeaders();
         Optional<Route> maybeRoute = routes.getMatch(request);
 
         return maybeRoute.
             map(this::headersFromRoute).
             orElseGet(this::buildHeaders);
+    }
+
+    private ArrayList<String> optionsHeaders() {
+        return new ResponseHeaders().allowedMethods(this.allowedMethods).toList();
     }
 
     @Override
@@ -63,18 +68,14 @@ public class DefinedContents extends Responder {
     }
 
     private ArrayList<String> headersFromRoute(Route route) {
-        ResponseHeaders headers = new ResponseHeaders();
-
-        return headers.
+        return new ResponseHeaders().
             withStatus(route.getResponseCode()).
             withContentType("text/html").
             toList();
     }
 
     private ArrayList<String> buildHeaders() {
-        ResponseHeaders headers = new ResponseHeaders();
-
-        return headers.withStatus(ResponseCode.notFound()).toList();
+        return new ResponseHeaders().withStatus(ResponseCode.notFound()).toList();
     }
 
 }

--- a/src/main/java/duckling/responders/FileContents.java
+++ b/src/main/java/duckling/responders/FileContents.java
@@ -37,7 +37,13 @@ public class FileContents extends Responder {
     public ArrayList<String> headers() throws IOException {
         ResponseHeaders headers = new ResponseHeaders();
 
-        if (!isAllowed()) return headers.notAllowed().toList();
+        if (request.isOptions()) {
+            return headers.allowedMethods(this.allowedMethods).toList();
+        }
+
+        if (!isAllowed()) {
+            return headers.notAllowed().toList();
+        }
 
         return headers.withContentType(getContentType()).toList();
     }

--- a/src/main/java/duckling/responders/FolderContents.java
+++ b/src/main/java/duckling/responders/FolderContents.java
@@ -40,7 +40,13 @@ public class FolderContents extends Responder {
     public ArrayList<String> headers() throws IOException {
         ResponseHeaders headers = new ResponseHeaders();
 
-        if (!isAllowed()) return headers.notAllowed().toList();
+        if (request.isOptions()) {
+            return headers.allowedMethods(this.allowedMethods).toList();
+        }
+
+        if (!isAllowed()) {
+            return headers.notAllowed().toList();
+        }
 
         return headers.withContentType("text/html").toList();
     }

--- a/src/main/java/duckling/responders/NotFound.java
+++ b/src/main/java/duckling/responders/NotFound.java
@@ -21,6 +21,10 @@ public class NotFound extends Responder {
 
     @Override
     public ArrayList<String> headers() throws IOException {
+        if (request.isOptions()) {
+            return new ResponseHeaders().allowedMethods(this.allowedMethods).toList();
+        }
+
         return new ResponseHeaders().notFound().withContentType("text/html").toList();
     }
 

--- a/src/main/java/duckling/responders/Responder.java
+++ b/src/main/java/duckling/responders/Responder.java
@@ -6,17 +6,14 @@ import duckling.requests.Request;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.Arrays;
 
 public abstract class Responder {
     protected Request request;
     protected Configuration config;
-    protected ArrayList<String> allowedMethods = new ArrayList<>();
-
-    {
-        this.allowedMethods.add("GET");
-        this.allowedMethods.add("HEAD");
-        this.allowedMethods.add("OPTIONS");
-    }
+    protected ArrayList<String> allowedMethods = new ArrayList<>(
+        Arrays.asList("GET", "HEAD", "OPTIONS")
+    );
 
     public Responder(Request request) {
         this(request, new Configuration());

--- a/src/main/java/duckling/responses/ResponseHeaders.java
+++ b/src/main/java/duckling/responses/ResponseHeaders.java
@@ -9,6 +9,7 @@ import java.util.stream.Collectors;
 public class ResponseHeaders {
     protected ResponseCode responseCode;
     protected String contentType;
+    protected ArrayList<String> permittedMethods;
 
     public ResponseHeaders() {
         this(ResponseCode.ok(), "null");
@@ -19,8 +20,29 @@ public class ResponseHeaders {
     }
 
     public ResponseHeaders(ResponseCode responseCode, String contentType) {
+        this(
+            responseCode,
+            contentType,
+            new ArrayList<>()
+        );
+    }
+
+    public ResponseHeaders(
+        ResponseCode responseCode,
+        String contentType,
+        ArrayList<String> permittedMethods
+    ) {
         this.contentType = contentType;
         this.responseCode = responseCode;
+        this.permittedMethods = permittedMethods;
+    }
+
+    public ResponseHeaders allowedMethods(ArrayList<String> permittedMethods) {
+        return new ResponseHeaders(
+            this.responseCode,
+            this.contentType,
+            permittedMethods
+        );
     }
 
     public ResponseHeaders notFound() {
@@ -36,9 +58,15 @@ public class ResponseHeaders {
     }
 
     public ArrayList<String> toList() {
+        return this.permittedMethods.size() > 0 ? optionsResponse() : completeResponse();
+    }
+
+    private ArrayList<String> optionsResponse() {
+        String allowed = this.permittedMethods.stream().collect(Collectors.joining(","));
+
         return new ArrayList<>(Arrays.asList(
             "HTTP/1.0 " + responseCode + Server.CRLF,
-            "Content-Type: " + contentType + Server.CRLF,
+            "Allow: " + allowed + Server.CRLF,
             Server.CRLF
         ));
     }
@@ -50,4 +78,13 @@ public class ResponseHeaders {
     public String toString() {
         return toList().stream().collect(Collectors.joining());
     }
+
+    private ArrayList<String> completeResponse() {
+        return new ArrayList<>(Arrays.asList(
+            "HTTP/1.0 " + responseCode + Server.CRLF,
+            "Content-Type: " + contentType + Server.CRLF,
+            Server.CRLF
+        ));
+    }
+
 }

--- a/src/test/java/duckling/requests/RequestTest.java
+++ b/src/test/java/duckling/requests/RequestTest.java
@@ -1,5 +1,7 @@
 package duckling.requests;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 
@@ -125,5 +127,19 @@ public class RequestTest {
             request.getBody(),
             "Body line one" + Server.CRLF + "Body line two"
         );
+    }
+
+    @Test
+    public void isOptionsReturnsFalseIfMethodIsNotOptions() throws Exception {
+        request.add("GET / HTTP/1.1");
+
+        assertThat(request.isOptions(), is(false));
+    }
+
+    @Test
+    public void isOptionsReturnsTrueIfMethodIsOptions() throws Exception {
+        request.add("OPTIONS / HTTP/1.1");
+
+        assertThat(request.isOptions(), is(true));
     }
 }

--- a/src/test/java/duckling/responders/DefinedContentsTest.java
+++ b/src/test/java/duckling/responders/DefinedContentsTest.java
@@ -72,6 +72,21 @@ public class DefinedContentsTest {
     }
 
     @Test
+    public void presentsGetHeadOptionsAsOptions() throws Exception {
+        request = new Request();
+        request.add("OPTIONS /coffee HTTP/1.1");
+
+        responder = new DefinedContents(request, config);
+
+        ArrayList<String> headers =
+            new ResponseHeaders().
+                allowedMethods(responder.allowedMethods).
+                toList();
+
+        assertThat(responder.headers(), is(headers));
+    }
+
+    @Test
     public void suppliesTheRouteDefinedBody() throws Exception {
         SpyOutputStream outputStream = new SpyOutputStream();
         InputStream inputStream = responder.body();

--- a/src/test/java/duckling/responders/FolderContentsTest.java
+++ b/src/test/java/duckling/responders/FolderContentsTest.java
@@ -76,6 +76,21 @@ public class FolderContentsTest {
     }
 
     @Test
+    public void presentsGetHeadOptionsAsOptions() throws Exception {
+        Request request = new Request();
+        request.add("OPTIONS /coffee HTTP/1.1");
+
+        FolderContents responder = new FolderContents(request);
+
+        ArrayList<String> headers =
+            new ResponseHeaders().
+                allowedMethods(responder.allowedMethods).
+                toList();
+
+        assertThat(responder.headers(), is(headers));
+    }
+
+    @Test
     public void disallowsNonGetRequests() throws Exception {
         Request request = new Request();
         request.add("PUT / HTTP/1.1");

--- a/src/test/java/duckling/responders/NotFoundTest.java
+++ b/src/test/java/duckling/responders/NotFoundTest.java
@@ -27,6 +27,21 @@ public class NotFoundTest {
     }
 
     @Test
+    public void presentsGetHeadOptionsAsOptions() throws Exception {
+        Request request = new Request();
+        request.add("OPTIONS /coffee HTTP/1.1");
+
+        responder = new NotFound(request);
+
+        ArrayList<String> headers =
+            new ResponseHeaders().
+                allowedMethods(responder.allowedMethods).
+                toList();
+
+        assertThat(responder.headers(), is(headers));
+    }
+
+    @Test
     public void providesHeadersWithHtmlContentType() throws Exception {
         ArrayList<String> headers =
             new ResponseHeaders().notFound().withContentType("text/html").toList();

--- a/src/test/java/duckling/responses/ResponseHeadersTest.java
+++ b/src/test/java/duckling/responses/ResponseHeadersTest.java
@@ -8,6 +8,7 @@ import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.stream.Collectors;
 
 public class ResponseHeadersTest {
     @Test
@@ -74,6 +75,25 @@ public class ResponseHeadersTest {
         ));
 
         assertThat(responseHeaders.toList(), is(list));
+    }
+
+    @Test
+    public void hasOptionsMode() throws Exception {
+        ArrayList<String> methods = new ArrayList<>(
+            Arrays.asList("GET", "HEAD", "OPTIONS")
+        );
+
+        String allowed = methods.stream().collect(Collectors.joining(","));
+
+        ArrayList<String> responseList = new ArrayList<>(Arrays.asList(
+            "HTTP/1.0 200 OK" + Server.CRLF,
+            "Allow: " + allowed + Server.CRLF,
+            Server.CRLF
+        ));
+
+        ResponseHeaders responseHeaders = new ResponseHeaders().allowedMethods(methods);
+
+        assertThat(responseHeaders.toList(), is(responseList));
     }
 
     @Test


### PR DESCRIPTION
In the event that a request is for options, we want to respond simply
with the options of a matching responder.