### PR TITLE
Rely on domain objects over foundational types.

### DIFF
--- a/src/main/java/duckling/Configuration.java
+++ b/src/main/java/duckling/Configuration.java
@@ -11,7 +11,7 @@ import java.util.Arrays;
 
 public class Configuration {
     public static final int DEFAULT_PORT = 5000;
-    public static final String DEFAULT_ROOT = "/var/www/duckling/public";
+    public static final String DEFAULT_ROOT = ".";
     public static final RouteDefinitions DEFAULT_ROUTES = new RouteDefinitions(
         Routes.get("/coffee").with("I'm a teapot").andRejectWith(418),
         Routes.get("/tea").with("Tea indeed")
@@ -23,6 +23,10 @@ public class Configuration {
 
     public Configuration() {
         this(DEFAULT_PORT, DEFAULT_ROOT);
+    }
+
+    public Configuration(String root) {
+        this(DEFAULT_PORT, root, DEFAULT_ROUTES);
     }
 
     public Configuration(RouteDefinitions routes) {

--- a/src/main/java/duckling/Server.java
+++ b/src/main/java/duckling/Server.java
@@ -70,21 +70,9 @@ public class Server {
     public void listen() throws IOException {
         onBegin();
 
-        Runnable shutdown = this::onShutdown;
-        Runtime.getRuntime().addShutdownHook(new Thread(shutdown));
+        Runtime.getRuntime().addShutdownHook(new Thread(this::onShutdown));
 
-        while (notShuttingDown()) onRequest();
+        while (!this.shuttingDown) onRequest();
     }
 
-    private boolean notShuttingDown() {
-        return !this.shuttingDown;
-    }
-
-    public int getPort() {
-        return this.config.port;
-    }
-
-    public String getRoot() {
-        return this.config.root;
-    }
 }

--- a/src/main/java/duckling/requests/BaseRequest.java
+++ b/src/main/java/duckling/requests/BaseRequest.java
@@ -1,0 +1,92 @@
+package duckling.requests;
+
+import java.util.Arrays;
+import java.util.Hashtable;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class BaseRequest {
+    public static final String METHOD = "Method";
+    public static final String PATH = "Path";
+    public static final String PROTOCOL = "Protocol";
+    public static final String EMPTY_PATH = "";
+    public static final String OPTIONS = "OPTIONS";
+    public static final String HEAD = "HEAD";
+    public static final String GET = "GET";
+
+    public static final int METHOD_INDEX = 0;
+    public static final int PATH_INDEX = 1;
+    public static final int PROTOCOL_INDEX = 2;
+    private static final String DEFAULT_PROTOCOL = "HTTP/1.0";
+
+    private Hashtable<String,String> contents = new Hashtable<>();
+    private String rawRequest = "";
+
+    public BaseRequest() {
+        this("");
+    }
+
+    public BaseRequest(String baseRequest) {
+        this.rawRequest = baseRequest;
+
+        List<String> tokens = Arrays.asList(baseRequest.split(" "));
+
+        try {
+            contents.put(METHOD, tokens.get(METHOD_INDEX));
+            contents.put(PATH, tokens.get(PATH_INDEX));
+            contents.put(PROTOCOL, tokens.get(PROTOCOL_INDEX));
+        } catch (ArrayIndexOutOfBoundsException exception) {
+        }
+    }
+
+    public BaseRequest set(String baseRequest) {
+        return new BaseRequest(baseRequest);
+    }
+
+    public String getMethod() {
+        return this.contents.getOrDefault(METHOD, GET);
+    }
+
+    public String getPath() {
+        return this.contents.getOrDefault(PATH, EMPTY_PATH);
+    }
+
+    private String getProtocol() {
+        return this.contents.getOrDefault(PROTOCOL, DEFAULT_PROTOCOL);
+    }
+
+
+    public String toString() {
+        return Stream.of(getMethod(), getPath(), getProtocol()).
+            collect(Collectors.joining(" "));
+    }
+
+    @Override
+    public int hashCode() {
+        return this.rawRequest.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return equals((BaseRequest) other);
+    }
+
+    public boolean equals(BaseRequest other) {
+        return this.rawRequest.equals(other.rawRequest);
+    }
+
+    public boolean isEmpty() {
+        return this.rawRequest.isEmpty();
+    }
+
+    public boolean isOptions() {
+        return getMethod().equals(OPTIONS);
+    }
+
+    public boolean isHead() {
+        return getMethod().equals(HEAD);
+    }
+
+}
+

--- a/src/main/java/duckling/requests/HeaderPair.java
+++ b/src/main/java/duckling/requests/HeaderPair.java
@@ -1,0 +1,49 @@
+package duckling.requests;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class HeaderPair {
+    private static final String KEY_VALUE_SEPARATOR = ": ";
+    private static final int KEY_INDEX = 0;
+    private static final int VALUE_INDEX = 1;
+
+    public String key = "";
+    public String value = "";
+
+    public HeaderPair(String line) {
+        List<String> headers = Arrays.asList(line.split(KEY_VALUE_SEPARATOR));
+
+        try {
+            this.key = headers.get(KEY_INDEX);
+            this.value = headers.get(VALUE_INDEX);
+        } catch (ArrayIndexOutOfBoundsException exception) {
+        }
+    }
+
+    public boolean matches(String key) {
+        return this.key.equals(key);
+    }
+
+    public String getValue() {
+        return this.value;
+    }
+
+    @Override
+    public int hashCode() {
+        return (this.key + this.value).hashCode();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return equals((HeaderPair) other);
+    }
+
+    public boolean equals(HeaderPair other) {
+        return this.key.equals(other.key) && this.value.equals(other.value);
+    }
+
+    public String toString() {
+        return this.key + ": " + this.value;
+    }
+}

--- a/src/main/java/duckling/requests/Headers.java
+++ b/src/main/java/duckling/requests/Headers.java
@@ -1,0 +1,57 @@
+package duckling.requests;
+
+import duckling.Server;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class Headers {
+    private List<HeaderPair> contents = new ArrayList<>();
+
+    public Headers(String... lines) {
+        Arrays.asList(lines).forEach(this::add);
+    }
+
+    public void add(String line) {
+        this.contents.add(new HeaderPair(line));
+    }
+
+    public String get(String key) {
+        return this.
+            contents.
+            stream().
+            filter(pair -> pair.matches(key)).
+            findFirst().
+            map(pair -> pair.getValue()).
+            orElse("");
+    }
+
+    public boolean isEmpty() {
+        return this.contents.size() == 0;
+    }
+
+    @Override
+    public int hashCode() {
+        return this.contents.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return equals((Headers) other);
+    }
+
+    public boolean equals(Headers other) {
+        return this.contents.equals(other.contents);
+    }
+
+    public String toString() {
+        return this.
+            contents.
+            stream().
+            map(pair -> pair.toString()).
+            collect(Collectors.joining(Server.CRLF));
+    }
+
+}

--- a/src/main/java/duckling/requests/RequestHandler.java
+++ b/src/main/java/duckling/requests/RequestHandler.java
@@ -1,17 +1,13 @@
 package duckling.requests;
 
 import duckling.Configuration;
-import duckling.writers.BodyWriter;
-import duckling.writers.HeadersWriter;
 import duckling.Logger;
-import duckling.responders.Responder;
 import duckling.responders.Responders;
 
 import java.io.IOException;
-import java.io.OutputStream;
 import java.net.Socket;
 import java.util.ArrayList;
-import java.util.function.Consumer;
+import java.util.List;
 
 public class RequestHandler implements Runnable {
     private final Configuration config;
@@ -19,15 +15,24 @@ public class RequestHandler implements Runnable {
     private final Logger logger;
     private ArrayList<String> loggables = new ArrayList<>();
 
+    public Request request;
+
     public RequestHandler(Socket client, Configuration config) {
         this(client, config, new Logger());
     }
 
     public RequestHandler(Socket client, Configuration config, Logger logger) {
+        this(client, config, logger, new Request(config));
+    }
+
+    public RequestHandler(Socket client, Configuration config, Logger logger, Request request) {
         this.client = client;
         this.config = config;
         this.logger = logger;
+        this.request = request;
+
     }
+
 
     @Override
     public void run() {
@@ -36,47 +41,24 @@ public class RequestHandler implements Runnable {
             this.client.close();
         } catch (IOException exception) {
             exception.printStackTrace();
+        } finally {
+            this.loggables.forEach(this.logger::info);
         }
-
     }
 
     private void handleRequest() throws IOException {
-        OutputStream output = this.client.getOutputStream();
         RequestStream requestStream = buildRequestStream();
-        Request request = prepareRequest();
+        List<String> requestLines = requestStream.toList();
 
-        Consumer<String> recordLine = line -> {
-            request.add(line);
-            loggables.add(line);
-        };
+        this.loggables.addAll(requestLines);
+        this.request.add(requestLines);
 
-        requestStream.toList().forEach(recordLine);
+        Responders.respondTo(request, this.client.getOutputStream(), this.config);
 
-        Responder responder = getResponder(request);
-        HeadersWriter headers = new HeadersWriter(responder, output);
-        BodyWriter body = new BodyWriter(responder, output);
-
-        loggables.add("");
-        loggables.add("Responding with " + responder.getClass().toString());
-        loggables.add("");
-        loggables.forEach(logger::info);
-
-        headers.write();
-        if (!request.getMethod().equals("HEAD")) body.write();
-    }
-
-    public Request prepareRequest() {
-        return new Request(this.config.root);
     }
 
     public RequestStream buildRequestStream() throws IOException {
         return new RequestStream(this.client.getInputStream());
-    }
-
-    public Responder getResponder(Request request) throws IOException {
-        Responders responders = new Responders(request, this.config);
-
-        return responders.getResponder();
     }
 
 }

--- a/src/main/java/duckling/responders/DefinedContents.java
+++ b/src/main/java/duckling/responders/DefinedContents.java
@@ -8,7 +8,6 @@ import duckling.routing.Route;
 import duckling.routing.RouteDefinitions;
 
 import java.io.ByteArrayInputStream;
-import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Optional;
@@ -31,7 +30,7 @@ public class DefinedContents extends Responder {
     }
 
     @Override
-    public ArrayList<String> headers() throws IOException {
+    public ArrayList<String> headers() {
         if (request.isOptions()) return optionsHeaders();
         Optional<Route> maybeRoute = routes.getMatch(request);
 
@@ -45,18 +44,13 @@ public class DefinedContents extends Responder {
     }
 
     @Override
-    public InputStream body() throws IOException {
+    public InputStream body() {
         Optional<Route> maybeRoute = routes.getMatch(request);
         String fileContent = maybeRoute.
             map(route -> buildContent(request.getPath(), route.getContent())).
             orElseGet(this::buildContent);
 
         return new ByteArrayInputStream(fileContent.getBytes());
-    }
-
-    @Override
-    public boolean isAllowed() {
-        return this.allowedMethods.contains(request.getMethod());
     }
 
     private String buildContent() {

--- a/src/main/java/duckling/responders/FileContents.java
+++ b/src/main/java/duckling/responders/FileContents.java
@@ -34,7 +34,7 @@ public class FileContents extends Responder {
     }
 
     @Override
-    public ArrayList<String> headers() throws IOException {
+    public ArrayList<String> headers() {
         ResponseHeaders headers = new ResponseHeaders();
 
         if (request.isOptions()) {
@@ -49,21 +49,20 @@ public class FileContents extends Responder {
     }
 
     @Override
-    public InputStream body() throws IOException {
+    public InputStream body() {
         return getFileStream();
     }
 
-    @Override
-    public boolean isAllowed() {
-        return this.allowedMethods.contains(request.getMethod());
-    }
-
-    private String getContentType() throws IOException {
+    private String getContentType() {
         String fromName = guessContentTypeFromName(this.file.getName());
 
-        if (fromName == null) {
-            return guessContentTypeFromStream(getFileStream());
-        } else {
+        try {
+            if (fromName == null) {
+                return guessContentTypeFromStream(getFileStream());
+            } else {
+                return fromName;
+            }
+        } catch (IOException exception) {
             return fromName;
         }
     }

--- a/src/main/java/duckling/responders/FolderContents.java
+++ b/src/main/java/duckling/responders/FolderContents.java
@@ -37,7 +37,7 @@ public class FolderContents extends Responder {
     }
 
     @Override
-    public ArrayList<String> headers() throws IOException {
+    public ArrayList<String> headers() {
         ResponseHeaders headers = new ResponseHeaders();
 
         if (request.isOptions()) {
@@ -52,15 +52,10 @@ public class FolderContents extends Responder {
     }
 
     @Override
-    public InputStream body() throws IOException {
+    public InputStream body() {
         String responseContent = !isAllowed() ? "" : rawFolderResponse();
 
         return new ByteArrayInputStream(responseContent.getBytes());
-    }
-
-    @Override
-    public boolean isAllowed() {
-        return this.allowedMethods.contains(request.getMethod());
     }
 
     private String rawFolderResponse() {

--- a/src/main/java/duckling/responders/NotFound.java
+++ b/src/main/java/duckling/responders/NotFound.java
@@ -20,7 +20,7 @@ public class NotFound extends Responder {
     }
 
     @Override
-    public ArrayList<String> headers() throws IOException {
+    public ArrayList<String> headers() {
         if (request.isOptions()) {
             return new ResponseHeaders().allowedMethods(this.allowedMethods).toList();
         }
@@ -29,7 +29,7 @@ public class NotFound extends Responder {
     }
 
     @Override
-    public InputStream body() throws IOException {
+    public InputStream body() {
         return new ByteArrayInputStream(rawResponse().getBytes());
     }
 

--- a/src/main/java/duckling/responders/Responder.java
+++ b/src/main/java/duckling/responders/Responder.java
@@ -26,10 +26,12 @@ public abstract class Responder {
 
     abstract public boolean matches();
 
-    abstract public ArrayList<String> headers() throws IOException;
+    abstract public ArrayList<String> headers();
 
-    abstract public InputStream body() throws IOException;
+    abstract public InputStream body();
 
-    abstract public boolean isAllowed();
+    public boolean isAllowed() {
+        return this.allowedMethods.contains(this.request.getMethod());
+    }
 
 }

--- a/src/main/java/duckling/responders/Responders.java
+++ b/src/main/java/duckling/responders/Responders.java
@@ -2,11 +2,20 @@ package duckling.responders;
 
 import duckling.Configuration;
 import duckling.requests.Request;
+import duckling.writers.BodyWriter;
+import duckling.writers.HeadersWriter;
+import duckling.writers.Writer;
 
+import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
 
 public class Responders {
+    private Configuration config;
     private Request request;
     private ArrayList<Responder> responders;
 
@@ -34,6 +43,7 @@ public class Responders {
         Collections.addAll(list, responders);
 
         this.request = request;
+        this.config = config;
         this.responders = list;
     }
 
@@ -42,7 +52,22 @@ public class Responders {
             stream().
             filter(Responder::matches).
             findFirst().
-            map((Responder candidate) -> candidate).
+            map(Function.identity()).
             orElseGet(() -> new NotFound(request));
+    }
+
+    public static void respondTo(
+        Request request,
+        OutputStream output,
+        Configuration config
+    ) {
+        Responder responder = new Responders(request, config).getResponder();
+        Predicate<Writer> respondsTo = writer -> writer.respondsTo(request);
+        Consumer<Writer> write = writer -> writer.write();
+
+        Stream.of(
+            new HeadersWriter(responder, output),
+            new BodyWriter(responder, output)
+        ).filter(respondsTo).forEach(write);
     }
 }

--- a/src/main/java/duckling/writers/BodyWriter.java
+++ b/src/main/java/duckling/writers/BodyWriter.java
@@ -1,5 +1,6 @@
 package duckling.writers;
 
+import duckling.requests.Request;
 import duckling.responders.Responder;
 
 import java.io.IOException;
@@ -11,10 +12,21 @@ public class BodyWriter extends Writer {
         super(responder, output);
     }
 
-    public void write() throws IOException {
+    public void write() {
         int input;
-        InputStream body = responder.body();
+        InputStream body = null;
 
-        while ((input = body.read()) != -1) output.write(input);
+        try {
+            body = responder.body();
+            while ((input = body.read()) != -1) output.write(input);
+        } catch (IOException exception) {
+            exception.printStackTrace();
+        }
+
+    }
+
+    @Override
+    public boolean respondsTo(Request request) {
+        return !request.isHead();
     }
 }

--- a/src/main/java/duckling/writers/HeadersWriter.java
+++ b/src/main/java/duckling/writers/HeadersWriter.java
@@ -1,10 +1,12 @@
 package duckling.writers;
 
+import duckling.requests.Request;
 import duckling.responders.Responder;
 
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.List;
+import java.util.function.Consumer;
 
 public class HeadersWriter extends Writer {
 
@@ -12,18 +14,23 @@ public class HeadersWriter extends Writer {
         super(responder, output);
     }
 
-    public void write() throws IOException {
-        List<String> headers = responder.headers();
+    public void write() {
+        List<String> headers = null;
+        headers = responder.headers();
+        Consumer<String> writeLine = line -> {
+            try {
+                this.output.write(line.getBytes());
+            } catch (IOException exception) {
+                exception.printStackTrace();
+            }
+        };
 
-        headers.forEach(this::writeLine);
+        headers.forEach(writeLine);
     }
 
-    private void writeLine(String line) {
-        try {
-            output.write(line.getBytes());
-        } catch (IOException exception) {
-            exception.printStackTrace();
-        }
+    @Override
+    public boolean respondsTo(Request request) {
+        return true;
     }
 
 }

--- a/src/main/java/duckling/writers/Writer.java
+++ b/src/main/java/duckling/writers/Writer.java
@@ -1,5 +1,6 @@
 package duckling.writers;
 
+import duckling.requests.Request;
 import duckling.responders.Responder;
 
 import java.io.IOException;
@@ -14,6 +15,8 @@ public abstract class Writer {
         this.output = output;
     }
 
-    abstract public void write() throws IOException;
+    abstract public void write();
+
+    public abstract boolean respondsTo(Request request);
 }
 

--- a/src/test/java/duckling/ConfigurationTest.java
+++ b/src/test/java/duckling/ConfigurationTest.java
@@ -29,7 +29,7 @@ public class ConfigurationTest {
         String[] arguments = {};
         Configuration config = new Configuration(arguments);
 
-        assertEquals(config.root, "/var/www/duckling/public");
+        assertEquals(config.root, ".");
     }
 
     @Test(expected = BadArgumentsError.class)

--- a/src/test/java/duckling/ServerTest.java
+++ b/src/test/java/duckling/ServerTest.java
@@ -30,16 +30,6 @@ public class ServerTest {
     }
 
     @Test
-    public void definePort() throws Exception {
-        assertEquals(port, server.getPort());
-    }
-
-    @Test
-    public void defineRoot() throws Exception {
-        assertEquals(root, server.getRoot());
-    }
-
-    @Test
     public void beforeListenBindsConnection() throws Exception {
         server.onBegin();
         assertEquals(true, connection.isBound());

--- a/src/test/java/duckling/requests/BaseRequestTest.java
+++ b/src/test/java/duckling/requests/BaseRequestTest.java
@@ -1,0 +1,70 @@
+package duckling.requests;
+
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class BaseRequestTest {
+
+    @Test
+    public void storesGivenMethod() throws Exception {
+        BaseRequest baseRequest = new BaseRequest("GET / HTTP/1.1");
+        assertThat(baseRequest.getMethod(), is("GET"));
+    }
+
+    @Test
+    public void storesGivenPath() throws Exception {
+        BaseRequest baseRequest = new BaseRequest("GET / HTTP/1.1");
+        assertThat(baseRequest.getPath(), is("/"));
+    }
+
+    @Test
+    public void isEqualToSameRequest() throws Exception {
+        BaseRequest baseRequest = new BaseRequest("GET / HTTP/1.1");
+        BaseRequest other = new BaseRequest("GET / HTTP/1.1");
+        assertThat(baseRequest, is(other));
+    }
+
+    @Test
+    public void isNotEqualToDifferentRequest() throws Exception {
+        BaseRequest baseRequest = new BaseRequest("GET / HTTP/1.1");
+        BaseRequest other = new BaseRequest("GET /beans HTTP/1.1");
+        assertThat(baseRequest, is(not(other)));
+    }
+
+    @Test
+    public void canBeSetToNewRequestImmutably() throws Exception {
+        BaseRequest baseRequest = new BaseRequest("GET / HTTP/1.1");
+        BaseRequest other = baseRequest.set("POST / HTTP/1.1");
+        assertThat(baseRequest, is(not(other)));
+
+    }
+
+    @Test
+    public void isEmptyWhenGivenEmptyRequest() throws Exception {
+        BaseRequest baseRequest = new BaseRequest("");
+        assertThat(baseRequest.isEmpty(), is(true));
+    }
+
+    @Test
+    public void isOptionsWhenGivenOptionsRequest() throws Exception {
+        BaseRequest baseRequest = new BaseRequest("OPTIONS / HTTP/1.1");
+        assertThat(baseRequest.isOptions(), is(true));
+    }
+
+    @Test
+    public void isHeadWhenGivenHeadRequest() throws Exception {
+        BaseRequest baseRequest = new BaseRequest("HEAD / HTTP/1.1");
+        assertThat(baseRequest.isHead(), is(true));
+    }
+
+    @Test
+    public void rendersGivenRequestWhenTurnedToString() throws Exception {
+        String requestLine = "GET / HTTP/1.1";
+        BaseRequest baseRequest = new BaseRequest(requestLine);
+        assertThat(baseRequest.toString(), is(requestLine));
+    }
+
+}

--- a/src/test/java/duckling/requests/HeaderPairTest.java
+++ b/src/test/java/duckling/requests/HeaderPairTest.java
@@ -1,0 +1,51 @@
+package duckling.requests;
+
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class HeaderPairTest {
+
+    @Test
+    public void getValueReturnsValue() {
+        HeaderPair headerPair = new HeaderPair("Key: Value");
+        assertThat(headerPair.getValue(), is("Value"));
+    }
+
+    @Test
+    public void equalsSameKeyValue() {
+        HeaderPair headerPair = new HeaderPair("Key: Value");
+        HeaderPair other = new HeaderPair("Key: Value");
+        assertThat(headerPair, is(other));
+    }
+
+    @Test
+    public void doesNotEqualDifferentKey() {
+        HeaderPair headerPair = new HeaderPair("Key: Value");
+        HeaderPair other = new HeaderPair("Kia: Value");
+        assertThat(headerPair, is(not(other)));
+    }
+
+    @Test
+    public void doesNotEqualDifferentValue() {
+        HeaderPair headerPair = new HeaderPair("Key: Value");
+        HeaderPair other = new HeaderPair("Key: Valois");
+        assertThat(headerPair, is(not(other)));
+    }
+
+    @Test
+    public void matchesAgainstKey() {
+        HeaderPair headerPair = new HeaderPair("Key: Value");
+        assertThat(headerPair.matches("Key"), is(true));
+    }
+
+    @Test
+    public void presentsKeyValueAsToString() {
+        String keyValue = "Key: Value";
+        HeaderPair headerPair = new HeaderPair(keyValue);
+        assertThat(headerPair.toString(), is(keyValue));
+    }
+
+}

--- a/src/test/java/duckling/requests/HeadersTest.java
+++ b/src/test/java/duckling/requests/HeadersTest.java
@@ -1,0 +1,61 @@
+package duckling.requests;
+
+import duckling.Server;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsNot.not;
+
+public class HeadersTest {
+    @Test
+    public void isEmptyAtFirst() throws Exception {
+        Headers headers = new Headers();
+        assertThat(headers.isEmpty(), is(true));
+    }
+
+    @Test
+    public void gettingAnUndefinedHeaderReturnsAnEmptyString() throws Exception {
+        Headers headers = new Headers();
+        assertThat(headers.get("Key"), is(""));
+    }
+
+    @Test
+    public void gettingAnExistingHeaderReturnsTheHeaderValue() throws Exception {
+        Headers headers = new Headers("Key: Value");
+        assertThat(headers.get("Key"), is("Value"));
+    }
+
+    @Test
+    public void isEqualWhenAllPairsMatch() throws Exception {
+        Headers headers = new Headers("Key: Value", "KeyTwo: ValueTwo");
+        Headers other = new Headers("Key: Value", "KeyTwo: ValueTwo");
+        assertThat(headers, is(other));
+    }
+
+    @Test
+    public void isNotEqualWhenPairsDoNotMatch() throws Exception {
+        Headers headers = new Headers("Key: Value", "KeyTwo: ValueTwo");
+        Headers other = new Headers("Key: Value");
+        assertThat(headers, is(not(other)));
+    }
+
+    @Test
+    public void outputsKeyValuePairsForToString() throws Exception {
+        String[] lines = { "Key: Value", "KeyTwo: ValueTwo" };
+        Headers headers = new Headers(lines);
+
+        String asOutput =
+            Arrays.
+                stream(lines).
+                collect(
+                    Collectors.joining(Server.CRLF)
+                );
+
+        assertThat(headers.toString(), is(asOutput));
+    }
+
+}

--- a/src/test/java/duckling/requests/RequestHandlerTest.java
+++ b/src/test/java/duckling/requests/RequestHandlerTest.java
@@ -9,12 +9,9 @@ import duckling.support.SpySocket;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 
 import static org.hamcrest.CoreMatchers.*;
@@ -34,11 +31,6 @@ public class RequestHandlerTest {
         config = new Configuration(5151, root);
         logger = new SpyLogger();
         handler = new RequestHandler(client, config, logger);
-    }
-
-    @Test
-    public void buildRequestUsesGivenRoot() throws Exception {
-        assertThat(handler.prepareRequest().getRoot(), is(root));
     }
 
     @Test
@@ -85,12 +77,7 @@ public class RequestHandlerTest {
             }
         };
 
-        RequestHandler handler = new RequestHandler(client, config, logger) {
-            @Override
-            public Request prepareRequest() {
-                return request;
-            }
-
+        RequestHandler handler = new RequestHandler(client, config, logger, request) {
             @Override
             public RequestStream buildRequestStream() throws IOException {
                 return new RequestStream(client.getInputStream()) {

--- a/src/test/java/duckling/requests/RequestTest.java
+++ b/src/test/java/duckling/requests/RequestTest.java
@@ -1,5 +1,6 @@
 package duckling.requests;
 
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
@@ -20,33 +21,11 @@ public class RequestTest {
     }
 
     @Test
-    public void withRoot() throws Exception {
-        String root = "/some/directory/path";
-        Request request = new Request(root);
-        assertEquals(root, request.getRoot());
-    }
-
-    @Test
-    public void withoutRoot() throws Exception {
-        Request request = new Request();
-        assertEquals(".", request.getRoot());
-    }
-
-    @Test
-    public void buildsFilePath() throws Exception {
-        String root = "/some/directory/path";
-        Request request = new Request(root);
-        request.add("GET /crazy.html HTTP/1.1");
-        assertEquals(root + "/crazy.html", request.fullFilePath());
-
-    }
-
-    @Test
     public void similarRequestsHaveSameHashCode() throws Exception {
         Request otherRequest = new Request();
         request.add("GET / HTTP/1.1");
         otherRequest.add("GET / HTTP/1.1");
-        assertEquals(request.hashCode(), otherRequest.hashCode());
+        assertThat(request.hashCode(), is(otherRequest.hashCode()));
     }
 
     @Test
@@ -62,7 +41,8 @@ public class RequestTest {
         Request otherRequest = new Request();
         request.add("GET / HTTP/1.1");
         otherRequest.add("GET / HTTP/1.1");
-        assertEquals(true, request.equals(otherRequest));
+
+        assertThat(request, is(equalTo(otherRequest)));
     }
 
     @Test
@@ -71,12 +51,6 @@ public class RequestTest {
         request.add("GET / HTTP/1.1");
         otherRequest.add("GET / HTTP/1.0");
         assertEquals(false, request.equals(otherRequest));
-    }
-
-    @Test
-    public void firstLineIsInitialRequest() throws Exception {
-        request.add("GET / HTTP/1.1");
-        assertEquals(request.initialRequestString(), "GET / HTTP/1.1");
     }
 
     @Test
@@ -98,48 +72,36 @@ public class RequestTest {
     }
 
     @Test
-    public void marshalsInitialRequestProtocol() throws Exception {
-        request.add("GET / HTTP/1.1");
-        assertEquals(request.getProtocol(), "HTTP/1.1");
-    }
-
-    @Test
     public void additionalLinesAreHeaders() throws Exception {
-        request.add("GET / HTTP/1.1");
-        request.add("Host: localhost");
-        assertEquals(request.getHeader("Host"), "localhost");
-    }
-
-    @Test
-    public void setAcceptingBody() throws Exception {
-        request.setAcceptingBody();
-        assertEquals(true, request.isAcceptingBody());
-    }
-
-    @Test
-    public void bodyFollowsAnEmptyLine() throws Exception {
-        request.add("GET / HTTP/1.1");
-        request.add("");
-        request.add("Body line one");
-        request.add("Body line two");
-
-        assertEquals(
-            request.getBody(),
-            "Body line one" + Server.CRLF + "Body line two"
+        request.add(
+            "GET / HTTP/1.1",
+            "Host: localhost"
         );
+        assertEquals(request.headers.get("Host"), "localhost");
+    }
+
+    @Test
+    public void isHeadReturnsFalseIfMethodIsNotHead() throws Exception {
+        request.add("GET / HTTP/1.1");
+        assertThat(request.isHead(), is(false));
+    }
+
+    @Test
+    public void isHeadReturnsTrueIfMethodIsHead() throws Exception {
+        request.add("HEAD / HTTP/1.1");
+        assertThat(request.isHead(), is(true));
     }
 
     @Test
     public void isOptionsReturnsFalseIfMethodIsNotOptions() throws Exception {
         request.add("GET / HTTP/1.1");
-
         assertThat(request.isOptions(), is(false));
     }
 
     @Test
     public void isOptionsReturnsTrueIfMethodIsOptions() throws Exception {
         request.add("OPTIONS / HTTP/1.1");
-
         assertThat(request.isOptions(), is(true));
     }
+
 }

--- a/src/test/java/duckling/responders/FileContentsTest.java
+++ b/src/test/java/duckling/responders/FileContentsTest.java
@@ -75,8 +75,9 @@ public class FileContentsTest {
 
     @Test
     public void providesHeadersWithContentType() throws Exception {
+        request.add("GET /file.txt HTTP/1.1");
         File file = new File("file.txt");
-        FileContents responder = new FileContents(file);
+        FileContents responder = new FileContents(request, file);
         ArrayList<String> headers =
             new ResponseHeaders().withContentType("text/plain").toList();
 

--- a/src/test/java/duckling/responders/FolderContentsTest.java
+++ b/src/test/java/duckling/responders/FolderContentsTest.java
@@ -68,6 +68,7 @@ public class FolderContentsTest {
     @Test
     public void providesHeadersWithHtmlContentType() throws Exception {
         Request request = new Request();
+        request.add("GET / HTTP/1.1");
         FolderContents responder = new FolderContents(request);
         ArrayList<String> headers =
             new ResponseHeaders().withContentType("text/html").toList();
@@ -124,7 +125,9 @@ public class FolderContentsTest {
 
     @Test
     public void providesStreamOfEmptyPageAsBody() throws Exception {
-        FolderContents responder = new FolderContents(new Request()) {
+        Request request = new Request();
+        request.add("GET / HTTP/1.1");
+        FolderContents responder = new FolderContents(request) {
             @Override
             public String contents() {
                 return "";

--- a/src/test/java/duckling/responders/RespondersTest.java
+++ b/src/test/java/duckling/responders/RespondersTest.java
@@ -63,12 +63,12 @@ public class RespondersTest {
         }
 
         @Override
-        public ArrayList<String> headers() throws IOException {
+        public ArrayList<String> headers() {
             return null;
         }
 
         @Override
-        public InputStream body() throws IOException {
+        public InputStream body() {
             return null;
         }
 
@@ -89,12 +89,12 @@ public class RespondersTest {
         }
 
         @Override
-        public ArrayList<String> headers() throws IOException {
+        public ArrayList<String> headers() {
             return null;
         }
 
         @Override
-        public InputStream body() throws IOException {
+        public InputStream body() {
             return null;
         }
 

--- a/src/test/java/duckling/support/SpyResponder.java
+++ b/src/test/java/duckling/support/SpyResponder.java
@@ -51,13 +51,13 @@ public class SpyResponder extends Responder {
     }
 
     @Override
-    public ArrayList<String> headers() throws IOException {
+    public ArrayList<String> headers() {
         this.wereHeadersCalled = true;
         return this.list;
     }
 
     @Override
-    public InputStream body() throws IOException {
+    public InputStream body() {
         this.wasBodyCalled = true;
         return this.inputStream;
     }

--- a/src/test/java/duckling/support/SpyResponders.java
+++ b/src/test/java/duckling/support/SpyResponders.java
@@ -7,7 +7,7 @@ public class SpyResponders extends Responders {
     private boolean wasRespondCalled = false;
 
     public SpyResponders() {
-        this(new Request("."));
+        this(new Request());
     }
 
     public SpyResponders(Request request) {


### PR DESCRIPTION
The primary drive behind this commit is to re-establish some familiarity
with code I haven't meaningfully looked into for a few weeks.  Since
some of this code had in the downtime become legacy code to me, this
pass focuses on cleaning up some technical debt.

My main tactic here was to increase the amount of domain objects I use
to model out what Duckling does.  Where before I may have had a good
amount of naked foundational types (Hashtable, for example, for
Headers), I'm now wrapping that foundational type reliance with domain
objects.

As it turned out, in most cases these domain objects have operational
use outside of simply being good for organization - and after
introducing many of them, the rest of Duckling's architecture definitely
got a bit simpler.  Simpler to read and simpler to change; cool!

Hopefully this debt pass will arm me to make some quick augmentations
later this week.