### PR TITLE
Don't rely on overloaded equivalence checks.

### DIFF
--- a/src/main/java/duckling/requests/BaseRequest.java
+++ b/src/main/java/duckling/requests/BaseRequest.java
@@ -56,26 +56,6 @@ public class BaseRequest {
         return this.contents.getOrDefault(PROTOCOL, DEFAULT_PROTOCOL);
     }
 
-
-    public String toString() {
-        return Stream.of(getMethod(), getPath(), getProtocol()).
-            collect(Collectors.joining(" "));
-    }
-
-    @Override
-    public int hashCode() {
-        return this.rawRequest.hashCode();
-    }
-
-    @Override
-    public boolean equals(Object other) {
-        return equals((BaseRequest) other);
-    }
-
-    public boolean equals(BaseRequest other) {
-        return this.rawRequest.equals(other.rawRequest);
-    }
-
     public boolean isEmpty() {
         return this.rawRequest.isEmpty();
     }
@@ -86,6 +66,28 @@ public class BaseRequest {
 
     public boolean isHead() {
         return getMethod().equals(HEAD);
+    }
+
+    @Override
+    public int hashCode() {
+        return this.rawRequest.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        if (object instanceof BaseRequest) {
+            BaseRequest other = (BaseRequest) object;
+
+            return this.rawRequest.equals(other.rawRequest);
+        }
+
+        return false;
+    }
+
+    @Override
+    public String toString() {
+        return Stream.of(getMethod(), getPath(), getProtocol()).
+            collect(Collectors.joining(" "));
     }
 
 }

--- a/src/main/java/duckling/requests/HeaderPair.java
+++ b/src/main/java/duckling/requests/HeaderPair.java
@@ -21,12 +21,12 @@ public class HeaderPair {
         }
     }
 
-    public boolean matches(String key) {
-        return this.key.equals(key);
-    }
-
     public String getValue() {
         return this.value;
+    }
+
+    public boolean matches(String key) {
+        return this.key.equals(key);
     }
 
     @Override
@@ -35,14 +35,18 @@ public class HeaderPair {
     }
 
     @Override
-    public boolean equals(Object other) {
-        return equals((HeaderPair) other);
+    public boolean equals(Object object) {
+        if (object instanceof HeaderPair) {
+            HeaderPair other = (HeaderPair) object;
+
+            return this.key.equals(other.key) &&
+                this.value.equals(other.value);
+        }
+
+        return false;
     }
 
-    public boolean equals(HeaderPair other) {
-        return this.key.equals(other.key) && this.value.equals(other.value);
-    }
-
+    @Override
     public String toString() {
         return this.key + ": " + this.value;
     }

--- a/src/main/java/duckling/requests/Headers.java
+++ b/src/main/java/duckling/requests/Headers.java
@@ -38,14 +38,16 @@ public class Headers {
     }
 
     @Override
-    public boolean equals(Object other) {
-        return equals((Headers) other);
+    public boolean equals(Object object) {
+        if (object instanceof Headers) {
+            Headers other = (Headers) object;
+
+            return this.contents.equals(other.contents);
+        }
+        return false;
     }
 
-    public boolean equals(Headers other) {
-        return this.contents.equals(other.contents);
-    }
-
+    @Override
     public String toString() {
         return this.
             contents.

--- a/src/main/java/duckling/requests/Request.java
+++ b/src/main/java/duckling/requests/Request.java
@@ -68,22 +68,27 @@ public class Request {
         return this.baseRequest.isHead();
     }
 
+    @Override
     public int hashCode() {
         return this.baseRequest.hashCode() +
             this.body.hashCode() +
             this.headers.hashCode();
     }
 
-    public boolean equals(Object other) {
-        return equals((Request) other);
+    @Override
+    public boolean equals(Object object) {
+        if (object instanceof Request) {
+            Request other = (Request) object;
+
+            return this.baseRequest.equals(other.baseRequest)
+                && this.body.equals(other.body)
+                && this.headers.equals(other.headers);
+        }
+
+        return false;
     }
 
-    public boolean equals(Request other) {
-        return this.baseRequest.equals(other.baseRequest)
-            && this.body.equals(other.body)
-            && this.headers.equals(other.headers);
-    }
-
+    @Override
     public String toString() {
         return baseRequest.toString() + Server.CRLF +
             headers.toString() + Server.CRLF +

--- a/src/main/java/duckling/requests/RequestHandler.java
+++ b/src/main/java/duckling/requests/RequestHandler.java
@@ -30,9 +30,7 @@ public class RequestHandler implements Runnable {
         this.config = config;
         this.logger = logger;
         this.request = request;
-
     }
-
 
     @Override
     public void run() {

--- a/src/main/java/duckling/responders/FileContents.java
+++ b/src/main/java/duckling/responders/FileContents.java
@@ -29,8 +29,8 @@ public class FileContents extends Responder {
     }
 
     @Override
-    public boolean matches() {
-        return this.file.exists() && !this.file.isDirectory();
+    public InputStream body() {
+        return getFileStream();
     }
 
     @Override
@@ -49,8 +49,8 @@ public class FileContents extends Responder {
     }
 
     @Override
-    public InputStream body() {
-        return getFileStream();
+    public boolean matches() {
+        return this.file.exists() && !this.file.isDirectory();
     }
 
     private String getContentType() {

--- a/src/main/java/duckling/responders/FolderContents.java
+++ b/src/main/java/duckling/responders/FolderContents.java
@@ -32,8 +32,22 @@ public class FolderContents extends Responder {
     }
 
     @Override
-    public boolean matches() {
-        return this.directory.exists() && this.directory.isDirectory();
+    public InputStream body() {
+        String responseContent = !isAllowed() ? "" : rawFolderResponse();
+
+        return new ByteArrayInputStream(responseContent.getBytes());
+    }
+
+    public String contents() {
+        String[] list = this.directory.list();
+
+        if (list == null) {
+            return "";
+        }
+
+        Stream<String> links = Stream.of(list).map(this::toLink);
+
+        return links.collect(Collectors.joining());
     }
 
     @Override
@@ -52,10 +66,8 @@ public class FolderContents extends Responder {
     }
 
     @Override
-    public InputStream body() {
-        String responseContent = !isAllowed() ? "" : rawFolderResponse();
-
-        return new ByteArrayInputStream(responseContent.getBytes());
+    public boolean matches() {
+        return this.directory.exists() && this.directory.isDirectory();
     }
 
     private String rawFolderResponse() {
@@ -63,18 +75,6 @@ public class FolderContents extends Responder {
         String template = "<html><head>%s</head><body>%s</body></html>";
 
         return String.format(template, title, contents());
-    }
-
-    public String contents() {
-        String[] list = this.directory.list();
-
-        if (list == null) {
-            return "";
-        }
-
-        Stream<String> links = Stream.of(list).map(this::toLink);
-
-        return links.collect(Collectors.joining());
     }
 
     private String toLink(String item) {

--- a/src/main/java/duckling/responders/NotFound.java
+++ b/src/main/java/duckling/responders/NotFound.java
@@ -15,8 +15,8 @@ public class NotFound extends Responder {
     }
 
     @Override
-    public boolean matches() {
-        return true;
+    public InputStream body() {
+        return new ByteArrayInputStream(rawResponse().getBytes());
     }
 
     @Override
@@ -29,12 +29,12 @@ public class NotFound extends Responder {
     }
 
     @Override
-    public InputStream body() {
-        return new ByteArrayInputStream(rawResponse().getBytes());
+    public boolean isAllowed() {
+        return true;
     }
 
     @Override
-    public boolean isAllowed() {
+    public boolean matches() {
         return true;
     }
 

--- a/src/main/java/duckling/responders/Responder.java
+++ b/src/main/java/duckling/responders/Responder.java
@@ -3,7 +3,6 @@ package duckling.responders;
 import duckling.Configuration;
 import duckling.requests.Request;
 
-import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -24,14 +23,14 @@ public abstract class Responder {
         this.request = request;
     }
 
-    abstract public boolean matches();
+    abstract public InputStream body();
 
     abstract public ArrayList<String> headers();
-
-    abstract public InputStream body();
 
     public boolean isAllowed() {
         return this.allowedMethods.contains(this.request.getMethod());
     }
+
+    abstract public boolean matches();
 
 }

--- a/src/main/java/duckling/responses/ResponseCode.java
+++ b/src/main/java/duckling/responses/ResponseCode.java
@@ -48,18 +48,23 @@ public class ResponseCode {
         return codes.get(code);
     }
 
+    @Override
     public int hashCode() {
         return message().hashCode();
     }
 
-    public boolean equals(Object other) {
-        return equals((ResponseCode) other);
+    @Override
+    public boolean equals(Object object) {
+        if (object instanceof ResponseCode) {
+            ResponseCode other = (ResponseCode) object;
+
+            return this.code == other.code;
+        }
+
+        return false;
     }
 
-    public boolean equals(ResponseCode other) {
-        return code == other.code;
-    }
-
+    @Override
     public String toString() {
         return code + " " + message();
     }

--- a/src/main/java/duckling/responses/ResponseHeaders.java
+++ b/src/main/java/duckling/responses/ResponseHeaders.java
@@ -45,6 +45,14 @@ public class ResponseHeaders {
         );
     }
 
+    public ArrayList<String> toList() {
+        return this.permittedMethods.size() > 0 ? optionsResponse() : completeResponse();
+    }
+
+    public ResponseHeaders notAllowed() {
+        return withStatus(ResponseCode.notAllowed());
+    }
+
     public ResponseHeaders notFound() {
         return withStatus(ResponseCode.notFound());
     }
@@ -57,24 +65,7 @@ public class ResponseHeaders {
         return new ResponseHeaders(responseCode, contentType);
     }
 
-    public ArrayList<String> toList() {
-        return this.permittedMethods.size() > 0 ? optionsResponse() : completeResponse();
-    }
-
-    private ArrayList<String> optionsResponse() {
-        String allowed = this.permittedMethods.stream().collect(Collectors.joining(","));
-
-        return new ArrayList<>(Arrays.asList(
-            "HTTP/1.0 " + responseCode + Server.CRLF,
-            "Allow: " + allowed + Server.CRLF,
-            Server.CRLF
-        ));
-    }
-
-    public ResponseHeaders notAllowed() {
-        return withStatus(ResponseCode.notAllowed());
-    }
-
+    @Override
     public String toString() {
         return toList().stream().collect(Collectors.joining());
     }
@@ -83,6 +74,16 @@ public class ResponseHeaders {
         return new ArrayList<>(Arrays.asList(
             "HTTP/1.0 " + responseCode + Server.CRLF,
             "Content-Type: " + contentType + Server.CRLF,
+            Server.CRLF
+        ));
+    }
+
+    private ArrayList<String> optionsResponse() {
+        String allowed = this.permittedMethods.stream().collect(Collectors.joining(","));
+
+        return new ArrayList<>(Arrays.asList(
+            "HTTP/1.0 " + responseCode + Server.CRLF,
+            "Allow: " + allowed + Server.CRLF,
             Server.CRLF
         ));
     }

--- a/src/main/java/duckling/routing/Route.java
+++ b/src/main/java/duckling/routing/Route.java
@@ -38,8 +38,12 @@ public class Route {
         this.responseCode = responseCode;
     }
 
-    public Route with(String responderKey) {
-        return new Route(method, routeName, responderKey);
+    public Route andRejectWith(int code) {
+        return new Route(method, routeName, responderKey, new ResponseCode(code));
+    }
+
+    public String getContent() {
+        return responderKey;
     }
 
     public boolean hasMethod(String method) {
@@ -54,36 +58,38 @@ public class Route {
         return this.routeName.equals(route);
     }
 
-    public int hashCode() {
-        return routeName.hashCode() + method.hashCode();
-    }
-
-    public boolean equals(Object other) {
-        return equals((Route) other);
-    }
-
-    public boolean equals(Route other) {
-        return routeName.equals(other.routeName) && method.equals(other.method);
+    public ResponseCode getResponseCode() {
+        return responseCode;
     }
 
     public boolean matches(Request request) {
         return equals(Routes.fromRequest(request));
     }
 
-    public Route andRejectWith(int code) {
-        return new Route(method, routeName, responderKey, new ResponseCode(code));
+    public Route with(String responderKey) {
+        return new Route(method, routeName, responderKey);
     }
 
-    public ResponseCode getResponseCode() {
-        return responseCode;
+    @Override
+    public int hashCode() {
+        return this.routeName.hashCode() + this.method.hashCode();
     }
 
+    @Override
+    public boolean equals(Object object) {
+        if (object instanceof Route) {
+            Route other = (Route) object;
+
+            return this.routeName.equals(other.routeName) &&
+                this.method.equals(other.method);
+        }
+
+        return false;
+    }
+
+    @Override
     public String toString() {
         return method + " " + routeName + " - " + responderKey + " " + responseCode;
-    }
-
-    public String getContent() {
-        return responderKey;
     }
 
 }

--- a/src/main/java/duckling/routing/RouteDefinitions.java
+++ b/src/main/java/duckling/routing/RouteDefinitions.java
@@ -13,26 +13,31 @@ public class RouteDefinitions {
         Collections.addAll(contents, routes);
     }
 
-    public int hashCode() {
-        return contents.hashCode();
-    }
-
-    public boolean equals(Object other) {
-        return equals((RouteDefinitions) other);
-    }
-
-    public boolean equals(RouteDefinitions other) {
-        return contents.equals(other.contents);
+    public Optional<Route> getMatch(Request request) {
+        return contents.stream().filter(route -> route.matches(request)).findFirst();
     }
 
     public boolean hasRoute(Request request) {
         return contents.stream().anyMatch(route -> route.matches(request));
     }
 
-    public Optional<Route> getMatch(Request request) {
-        return contents.stream().filter(route -> route.matches(request)).findFirst();
+    @Override
+    public int hashCode() {
+        return contents.hashCode();
     }
 
+    @Override
+    public boolean equals(Object object) {
+        if (object instanceof RouteDefinitions) {
+            RouteDefinitions other = (RouteDefinitions) object;
+
+            return this.contents.equals(other.contents);
+        }
+
+        return false;
+    }
+
+    @Override
     public String toString() {
         return contents.stream().map(Route::toString).collect(Collectors.joining(Server.CRLF));
     }

--- a/src/main/java/duckling/writers/Writer.java
+++ b/src/main/java/duckling/writers/Writer.java
@@ -3,7 +3,6 @@ package duckling.writers;
 import duckling.requests.Request;
 import duckling.responders.Responder;
 
-import java.io.IOException;
 import java.io.OutputStream;
 
 public abstract class Writer {


### PR DESCRIPTION
Previously I was overloading the `#equals` method on a number of
objects, but if they'd ever been given an object which couldn't have
been coerced in the direction I assumed, that method would have resulted
in an exception and crash.

This commit updates those equivalence checks to assume false, except in
the event that the given object is actually a comparable object (in
other words, it's an instance of the same object).  In the case that the
offered object is comparable, we use the same comparison heuristics.