### PR TITLE
Secret decoder

### DIFF
--- a/src/main/java/duckling/Configuration.java
+++ b/src/main/java/duckling/Configuration.java
@@ -1,18 +1,39 @@
 package duckling;
 
 import duckling.errors.BadArgumentsError;
+import duckling.requests.Request;
 import duckling.routing.RouteDefinitions;
 import duckling.routing.Routes;
 
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.InputStream;
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.stream.Collectors;
 
 public class Configuration {
     public static final int DEFAULT_PORT = 5000;
     public static final String DEFAULT_ROOT = ".";
     public static final RouteDefinitions DEFAULT_ROUTES = new RouteDefinitions(
+        Routes.get("/parameters").with((Request request) -> {
+            try {
+                ArrayList<String> lines = new ArrayList<>();
+
+                for (String line: request.getQuery().split("&")) {
+                    ArrayList<String> items = new ArrayList<>();
+                    String decoded = URLDecoder.decode(line, "utf-8");
+
+                    Collections.addAll(items, decoded.split("=", 2));
+
+                    lines.add(items.stream().collect(Collectors.joining(" = ")));
+                }
+
+                return lines.stream().collect(Collectors.joining(Server.CRLF));
+            } catch (UnsupportedEncodingException exception) {
+                return "Unable to parse request URL query params.";
+            }
+        }),
         Routes.get("/coffee").with("I'm a teapot").andRejectWith(418),
         Routes.get("/tea").with("Tea indeed")
     );

--- a/src/main/java/duckling/requests/BaseRequest.java
+++ b/src/main/java/duckling/requests/BaseRequest.java
@@ -3,6 +3,7 @@ package duckling.requests;
 import java.util.Arrays;
 import java.util.Hashtable;
 import java.util.List;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -10,6 +11,7 @@ public class BaseRequest {
     public static final String METHOD = "Method";
     public static final String PATH = "Path";
     public static final String PROTOCOL = "Protocol";
+    public static final String QUERY = "Query";
     public static final String EMPTY_PATH = "";
     public static final String OPTIONS = "OPTIONS";
     public static final String HEAD = "HEAD";
@@ -32,10 +34,27 @@ public class BaseRequest {
 
         List<String> tokens = Arrays.asList(baseRequest.split(" "));
 
+        Function<String,String> parsePath = (path) -> {
+            try {
+                return path.split("\\?")[0];
+            } catch (ArrayIndexOutOfBoundsException exception) {
+                return "";
+            }
+        };
+
+        Function<String,String> parseQuery = (path) -> {
+            try {
+                return path.split("\\?")[1];
+            } catch (ArrayIndexOutOfBoundsException exception) {
+                return "";
+            }
+        };
+
         try {
             contents.put(METHOD, tokens.get(METHOD_INDEX));
-            contents.put(PATH, tokens.get(PATH_INDEX));
+            contents.put(PATH, parsePath.apply(tokens.get(PATH_INDEX)));
             contents.put(PROTOCOL, tokens.get(PROTOCOL_INDEX));
+            contents.put(QUERY, parseQuery.apply(tokens.get(PATH_INDEX)));
         } catch (ArrayIndexOutOfBoundsException exception) {
         }
     }
@@ -51,6 +70,11 @@ public class BaseRequest {
     public String getPath() {
         return this.contents.getOrDefault(PATH, EMPTY_PATH);
     }
+
+    public String getQuery() {
+        return this.contents.getOrDefault(QUERY, EMPTY_PATH);
+    }
+
 
     private String getProtocol() {
         return this.contents.getOrDefault(PROTOCOL, DEFAULT_PROTOCOL);

--- a/src/main/java/duckling/requests/Request.java
+++ b/src/main/java/duckling/requests/Request.java
@@ -16,6 +16,7 @@ public class Request {
     protected ArrayList<String> body = new ArrayList<>();
 
     private Configuration config;
+    private String query;
 
     public Request() {
         this(new Configuration());
@@ -58,6 +59,10 @@ public class Request {
 
     public String getPath() {
         return this.baseRequest.getPath();
+    }
+
+    public String getQuery() {
+        return this.baseRequest.getQuery();
     }
 
     public boolean isOptions() {

--- a/src/main/java/duckling/responders/DefinedContents.java
+++ b/src/main/java/duckling/responders/DefinedContents.java
@@ -28,7 +28,7 @@ public class DefinedContents extends Responder {
     public InputStream body() {
         Optional<Route> maybeRoute = routes.getMatch(request);
         String fileContent = maybeRoute.
-            map(route -> buildContent(request.getPath(), route.getContent())).
+            map(route -> buildContent(request.getPath(), route.getContent(request))).
             orElseGet(this::buildContent);
 
         return new ByteArrayInputStream(fileContent.getBytes());

--- a/src/main/java/duckling/routing/RouteContents.java
+++ b/src/main/java/duckling/routing/RouteContents.java
@@ -1,0 +1,56 @@
+package duckling.routing;
+
+import duckling.requests.Request;
+
+import java.util.function.Function;
+
+public class RouteContents {
+    private Request nullRequest = new Request();
+    private Function<Request, String> contents;
+
+    public RouteContents(String contents) {
+        this((request) -> contents);
+    }
+
+    public RouteContents(Function<Request, String> getContents) {
+        this.contents = getContents;
+    }
+
+    public String get(Request request) {
+        return this.contents.apply(request);
+    }
+
+    public String get() {
+        return get(this.nullRequest);
+    }
+
+    @Override
+    public int hashCode() {
+        return toString().hashCode();
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        if (object instanceof RouteContents) {
+            return equals((RouteContents) object);
+        } else if (object instanceof String) {
+            return equals((String) object);
+        }
+
+        return false;
+    }
+
+    public boolean equals(RouteContents other) {
+        return toString().equals(other.toString());
+    }
+
+    public boolean equals(String contents) {
+        return toString().equals(contents);
+    }
+
+    @Override
+    public String toString() {
+        return this.contents.apply(this.nullRequest);
+    }
+
+}

--- a/src/test/java/duckling/requests/BaseRequestTest.java
+++ b/src/test/java/duckling/requests/BaseRequestTest.java
@@ -15,6 +15,12 @@ public class BaseRequestTest {
     }
 
     @Test
+    public void storesGivenQueryParams() throws Exception {
+        BaseRequest baseRequest = new BaseRequest("GET /?stuff=things HTTP/1.1");
+        assertThat(baseRequest.getQuery(), is("stuff=things"));
+    }
+
+    @Test
     public void storesGivenPath() throws Exception {
         BaseRequest baseRequest = new BaseRequest("GET / HTTP/1.1");
         assertThat(baseRequest.getPath(), is("/"));

--- a/src/test/java/duckling/requests/RequestTest.java
+++ b/src/test/java/duckling/requests/RequestTest.java
@@ -66,6 +66,12 @@ public class RequestTest {
     }
 
     @Test
+    public void marshalsInitialRequestQuery() throws Exception {
+        request.add("GET /?stuff=things HTTP/1.1");
+        assertEquals(request.getQuery(), "stuff=things");
+    }
+
+    @Test
     public void providesPathFileReference() throws Exception {
         request.add("GET / HTTP/1.1");
         assertEquals(request.getFile(), new File("."));

--- a/src/test/java/duckling/routing/RouteContentsTest.java
+++ b/src/test/java/duckling/routing/RouteContentsTest.java
@@ -1,0 +1,62 @@
+package duckling.routing;
+
+import duckling.requests.Request;
+import org.junit.Test;
+
+import java.util.function.Function;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class RouteContentsTest {
+    @Test
+    public void getReturnsGivenString() throws Exception {
+        String body = "Heyyyy youuu guyyyysss";
+        RouteContents contents = new RouteContents(body);
+
+        assertThat(
+            contents.get(),
+            is(body)
+        );
+    }
+
+    @Test
+    public void getReturnsContentsOfGivenLambda() throws Exception {
+        String body = "Heyyyy youuu guyyyysss";
+        Function<Request, String> lambda = (Request request) -> body;
+        RouteContents contents = new RouteContents(lambda);
+
+        assertThat(
+            contents.get(),
+            is(body)
+        );
+    }
+
+    @Test
+    public void twoMatchingBodiesAreEquivalentContents() throws Exception {
+        String body = "Heyyyy youuu guyyyysss";
+        Function<Request, String> lambda = (Request request) -> body;
+        RouteContents closureContents = new RouteContents(lambda);
+        RouteContents stringContents = new RouteContents(body);
+
+        assertThat(
+            closureContents,
+            is(stringContents)
+        );
+    }
+
+    @Test
+    public void twoMismatchedContentsAreNotEquivalent() throws Exception {
+        String body = "Heyyyy youuu guyyyysss";
+        Function<Request, String> lambda = (Request request) -> "Baby ruth!";
+        RouteContents closureContents = new RouteContents(lambda);
+        RouteContents stringContents = new RouteContents(body);
+
+        assertThat(
+            closureContents,
+            is(not(stringContents))
+        );
+    }
+
+}


### PR DESCRIPTION
Routes previously only accepted strings, which they would use as bodies. This PR overhauls that a bit, by adding an object which can take a string or a (Request) -> String lambda.  Using this approach, we're able to create routes which can be custom engineered to serve a specific purpose without defining a new object for each new route.