### PR TITLE
Support redirects on the route level.

### DIFF
--- a/src/main/java/duckling/Configuration.java
+++ b/src/main/java/duckling/Configuration.java
@@ -16,6 +16,7 @@ public class Configuration {
     public static final int DEFAULT_PORT = 5000;
     public static final String DEFAULT_ROOT = ".";
     public static final RouteDefinitions DEFAULT_ROUTES = new RouteDefinitions(
+        Routes.get("/redirect").andRedirectTo("http://localhost:5000/"),
         Routes.get("/parameters").with((Request request) -> {
             try {
                 ArrayList<String> lines = new ArrayList<>();

--- a/src/main/java/duckling/responders/DefinedContents.java
+++ b/src/main/java/duckling/responders/DefinedContents.java
@@ -37,6 +37,7 @@ public class DefinedContents extends Responder {
     @Override
     public ArrayList<String> headers() {
         if (request.isOptions()) return optionsHeaders();
+
         Optional<Route> maybeRoute = routes.getMatch(request);
 
         return maybeRoute.
@@ -62,10 +63,16 @@ public class DefinedContents extends Responder {
     }
 
     private ArrayList<String> headersFromRoute(Route route) {
-        return new ResponseHeaders().
-            withStatus(route.getResponseCode()).
-            withContentType("text/html").
-            toList();
+        ResponseHeaders headers =
+            new ResponseHeaders().
+                withStatus(route.getResponseCode()).
+                withContentType("text/html");
+
+        if (route.isRedirect()) {
+            return headers.withLocation(route.getContent()).toList();
+        }
+
+        return headers.toList();
     }
 
     private ArrayList<String> optionsHeaders() {

--- a/src/main/java/duckling/responses/ResponseCode.java
+++ b/src/main/java/duckling/responses/ResponseCode.java
@@ -7,6 +7,7 @@ public class ResponseCode {
     public static final int NOT_FOUND = 404;
     public static final int TEAPOT = 418;
     public static final int METHOD_NOT_ALLOWED = 405;
+    public static final int FOUND = 302;
 
     private Hashtable<Integer, String> codes;
     private int code;
@@ -18,6 +19,7 @@ public class ResponseCode {
         codes.put(NOT_FOUND, "NOT FOUND");
         codes.put(TEAPOT, "TEAPOT");
         codes.put(METHOD_NOT_ALLOWED, "METHOD NOT ALLOWED");
+        codes.put(FOUND, "FOUND");
     }
 
     public ResponseCode() {
@@ -38,6 +40,10 @@ public class ResponseCode {
 
     public static ResponseCode notFound() {
         return new ResponseCode(NOT_FOUND);
+    }
+
+    public static ResponseCode found() {
+        return new ResponseCode(FOUND);
     }
 
     public static ResponseCode notAllowed() {

--- a/src/main/java/duckling/routing/Route.java
+++ b/src/main/java/duckling/routing/Route.java
@@ -59,6 +59,11 @@ public class Route {
         return new Route(method, routeName, routeContents, new ResponseCode(code));
     }
 
+    public Route andRedirectTo(String uri) {
+        RouteContents contents = new RouteContents(uri);
+        return new Route(method, routeName, contents, ResponseCode.found());
+    }
+
     public String getContent(Request request) {
         return this.routeContents.get(request);
     }
@@ -117,4 +122,7 @@ public class Route {
         return method + " " + routeName + " - " + routeContents + " " + responseCode;
     }
 
+    public boolean isRedirect() {
+        return responseCode.equals(ResponseCode.found());
+    }
 }

--- a/src/test/java/duckling/responders/DefinedContentsTest.java
+++ b/src/test/java/duckling/responders/DefinedContentsTest.java
@@ -49,6 +49,25 @@ public class DefinedContentsTest {
     }
 
     @Test
+    public void includesLocationDetailForRedirects() throws Exception {
+        Route routes = Routes.get("/redirect").andRedirectTo("/howdy");
+        Request request = new Request();
+        Configuration config = new Configuration(new RouteDefinitions(routes));
+
+        request.add("GET /redirect HTTP/1.1");
+
+        Responder responder = new DefinedContents(request, config);
+
+        ArrayList<String> headers =
+            new ResponseHeaders().
+                found("/howdy").
+                withContentType("text/html").
+                toList();
+
+        assertThat(responder.headers(), is(headers));
+    }
+
+    @Test
     public void suppliesCustomDefinedHeaders() throws Exception {
         request = new Request();
         request.add("GET /coffee HTTP/1.1");

--- a/src/test/java/duckling/responses/ResponseHeadersTest.java
+++ b/src/test/java/duckling/responses/ResponseHeadersTest.java
@@ -97,6 +97,21 @@ public class ResponseHeadersTest {
     }
 
     @Test
+    public void canBeARedirect() throws Exception {
+        ResponseHeaders responseHeaders =
+            new ResponseHeaders().found("/url");
+
+        ArrayList<String> list = new ArrayList<>(Arrays.asList(
+            "HTTP/1.0 302 FOUND" + Server.CRLF,
+            "Content-Type: null" + Server.CRLF,
+            "Location: /url" + Server.CRLF,
+            Server.CRLF
+        ));
+
+        assertThat(responseHeaders.toList(), is(list));
+    }
+
+    @Test
     public void asListCreatesList() throws Exception {
         ResponseHeaders responseHeaders = new ResponseHeaders().
             notFound().withContentType("text/html");

--- a/src/test/java/duckling/routing/RouteTest.java
+++ b/src/test/java/duckling/routing/RouteTest.java
@@ -30,6 +30,18 @@ public class RouteTest {
     }
 
     @Test
+    public void isRedirectReturnsTrueWhenIsRedirect() throws Exception {
+        Route route = new Route().andRedirectTo("/anywhere");
+        assertThat(route.isRedirect(), is(true));
+    }
+
+    @Test
+    public void isRedirectReturnsFalseWhenIsNotRedirect() throws Exception {
+        Route route = new Route();
+        assertThat(route.isRedirect(), is(false));
+    }
+
+    @Test
     public void acceptsRouteWithPrefix() throws Exception {
         String routeName = "/routes";
         Route route = new Route("GET", routeName);


### PR DESCRIPTION
This commit introduces redirect knowledge to the DefinedContents
object, all Response objects, and the Route object.  Basically, what
happens is that we treat a redirect as a normal content page, except we
add the content of the route to the headers list as a Location field.
This means that while we are rendering a string, most if not all clients
will point themselves towards the content as a destination URL.