### PR TITLE
Change redirect demo URI to absolute path.

### DIFF
--- a/src/main/java/duckling/Configuration.java
+++ b/src/main/java/duckling/Configuration.java
@@ -18,7 +18,7 @@ public class Configuration {
     public static final RouteDefinitions DEFAULT_ROUTES = new RouteDefinitions(
         Routes.put("/form"),
         Routes.post("/form"),
-        Routes.get("/redirect").andRedirectTo("http://localhost:5000/"),
+        Routes.get("/redirect").andRedirectTo("/"),
         Routes.get("/parameters").with((Request request) -> {
             try {
                 ArrayList<String> lines = new ArrayList<>();


### PR DESCRIPTION
We want to sort of forget any spot where duckling might have hard-wired
knowledge of its own domain or address.  That's what DNS is for.  This
commit removes a hard reference to `localhost:5000` in the /redirect
route.