### PR TITLE
Toss out some dead code.

### DIFF
--- a/src/main/java/duckling/Configuration.java
+++ b/src/main/java/duckling/Configuration.java
@@ -37,8 +37,8 @@ public class Configuration {
                 return "Unable to parse request URL query params.";
             }
         }),
-        Routes.get("/coffee").with("I'm a teapot").andRejectWith(418),
-        Routes.get("/tea").with("Tea indeed")
+        Routes.get("/coffee").with((request) -> "I'm a teapot").andRejectWith(418),
+        Routes.get("/tea").with((request) -> "Tea indeed")
     );
 
     public int port;
@@ -47,10 +47,6 @@ public class Configuration {
 
     public Configuration() {
         this(DEFAULT_PORT, DEFAULT_ROOT);
-    }
-
-    public Configuration(String root) {
-        this(DEFAULT_PORT, root, DEFAULT_ROUTES);
     }
 
     public Configuration(RouteDefinitions routes) {

--- a/src/main/java/duckling/requests/Request.java
+++ b/src/main/java/duckling/requests/Request.java
@@ -16,14 +16,9 @@ public class Request {
     protected ArrayList<String> body = new ArrayList<>();
 
     private Configuration config;
-    private String query;
 
     public Request() {
         this(new Configuration());
-    }
-
-    public Request(String root) {
-        this(new Configuration(root));
     }
 
     public Request(Configuration config) {

--- a/src/main/java/duckling/responders/DefinedContents.java
+++ b/src/main/java/duckling/responders/DefinedContents.java
@@ -19,7 +19,7 @@ public class DefinedContents extends Responder {
             "<body>%s</body></html>";
 
     public DefinedContents(Request request, Configuration config) {
-        super(request, config);
+        super(request);
 
         this.routes = config.routes;
     }

--- a/src/main/java/duckling/responders/Responder.java
+++ b/src/main/java/duckling/responders/Responder.java
@@ -1,6 +1,5 @@
 package duckling.responders;
 
-import duckling.Configuration;
 import duckling.requests.Request;
 
 import java.io.InputStream;
@@ -9,17 +8,11 @@ import java.util.Arrays;
 
 public abstract class Responder {
     protected Request request;
-    protected Configuration config;
     protected ArrayList<String> allowedMethods = new ArrayList<>(
         Arrays.asList("GET", "HEAD", "OPTIONS")
     );
 
     public Responder(Request request) {
-        this(request, new Configuration());
-    }
-
-    public Responder(Request request, Configuration config) {
-        this.config = config;
         this.request = request;
     }
 

--- a/src/main/java/duckling/responders/Responders.java
+++ b/src/main/java/duckling/responders/Responders.java
@@ -15,7 +15,6 @@ import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 public class Responders {
-    private Configuration config;
     private Request request;
     private ArrayList<Responder> responders;
 
@@ -26,7 +25,6 @@ public class Responders {
     public Responders(Request request, Configuration config) {
         this(
             request,
-            config,
             new DefinedContents(request, config),
             new FileContents(request),
             new FolderContents(request),
@@ -36,14 +34,12 @@ public class Responders {
 
     public Responders(
         Request request,
-        Configuration config,
         Responder... responders
     ) {
         ArrayList<Responder> list = new ArrayList<>();
         Collections.addAll(list, responders);
 
         this.request = request;
-        this.config = config;
         this.responders = list;
     }
 

--- a/src/main/java/duckling/routing/Route.java
+++ b/src/main/java/duckling/routing/Route.java
@@ -92,10 +92,6 @@ public class Route {
         return equals(Routes.fromRequest(request));
     }
 
-    public Route with(String routeContents) {
-        return with((request) -> routeContents);
-    }
-
     public Route with(Function<Request, String> routeContents) {
         return new Route(method, routeName, routeContents);
     }

--- a/src/test/java/duckling/responders/DefinedContentsTest.java
+++ b/src/test/java/duckling/responders/DefinedContentsTest.java
@@ -24,7 +24,7 @@ public class DefinedContentsTest {
 
     @Before
     public void setup() throws Exception {
-        Route routes = Routes.get("/tea").with("Tea indeed");
+        Route routes = Routes.get("/tea").with((request) -> "Tea indeed");
 
         request = new Request();
         request.add("GET /tea HTTP/1.1");
@@ -75,7 +75,7 @@ public class DefinedContentsTest {
         config = new Configuration(
             new RouteDefinitions(
                 Routes.get("/coffee").
-                    with("I'm a teapot").
+                    with((request) -> "I'm a teapot").
                     andRejectWith(ResponseCode.TEAPOT)
             )
         );

--- a/src/test/java/duckling/responders/RespondersTest.java
+++ b/src/test/java/duckling/responders/RespondersTest.java
@@ -3,7 +3,6 @@ package duckling.responders;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-import duckling.Configuration;
 import duckling.Server;
 import duckling.requests.RequestStream;
 import duckling.requests.Request;
@@ -44,7 +43,6 @@ public class RespondersTest {
     public void getResponderReturnsFirstMatch() throws IOException {
         Responders responders = new Responders(
             this.request,
-            new Configuration(),
             new NoMatchResponder(this.request),
             new MatchResponder(this.request)
         );

--- a/src/test/java/duckling/routing/RouteTest.java
+++ b/src/test/java/duckling/routing/RouteTest.java
@@ -25,7 +25,7 @@ public class RouteTest {
 
     @Test
     public void assignsResponderUsingWith() throws Exception {
-        Route route = new Route().with("supercool");
+        Route route = new Route().with((request) -> "supercool");
         assertThat(route.hasResponder("supercool"), is(true));
     }
 


### PR DESCRIPTION
There were a few old concepts and unnecessary variable declarations
going on.  This commit removes a few of the headliners:

* Where we had two types of RouteContents (string, vs. function which
  takes a request and returns a string), we now only have one type.  All
  routes expect to respond with, essentially, a lambda which generates
  response content.

* In several spots we were grabbing configuration details and then just
  letting them hang out or passing them around into even more objects
  which didn't really care about the details.  If it sounds like
  nonsense then that might give you a hint as to how much sense the code
  made.  Those instances are gone.