### PR TITLE
Replace complex response lambda with Converter.

### DIFF
--- a/src/main/java/duckling/requests/ParamConverter.java
+++ b/src/main/java/duckling/requests/ParamConverter.java
@@ -1,0 +1,20 @@
+package duckling.requests;
+
+import duckling.Server;
+
+import java.util.HashMap;
+import java.util.function.Function;
+
+public class ParamConverter implements Function<Request, String> {
+
+    @Override
+    public String apply(Request request) {
+        StringBuilder builder = new StringBuilder();
+        ParamExtractor extractor = new ParamExtractor();
+        HashMap<String, String> params = extractor.apply(request);
+
+        params.forEach((key, value) -> builder.append(key + " = " + value + Server.CRLF));
+
+        return builder.toString();
+    }
+}

--- a/src/main/java/duckling/requests/ParamExtractor.java
+++ b/src/main/java/duckling/requests/ParamExtractor.java
@@ -1,0 +1,29 @@
+package duckling.requests;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+public class ParamExtractor implements Function<Request, HashMap<String, String>> {
+    @Override
+    public HashMap<String, String> apply(Request request) {
+        String query = request.getQuery();
+        String[] rawParams = query.split("&");
+        Stream<String[]> parsedParams = Arrays.asList(rawParams).stream().map((String s) -> s.split("=", 2));
+
+        HashMap<String, String> params = new HashMap<>();
+
+        parsedParams.forEach((String[] paramPair) -> {
+            try {
+                params.put(paramPair[0], URLDecoder.decode(paramPair[1], "utf-8"));
+            } catch (UnsupportedEncodingException exception) {
+                exception.printStackTrace();
+            }
+        });
+
+        return params;
+    }
+}

--- a/src/test/java/duckling/requests/ParamConverterTest.java
+++ b/src/test/java/duckling/requests/ParamConverterTest.java
@@ -1,0 +1,28 @@
+package duckling.requests;
+
+import duckling.Server;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class ParamConverterTest {
+    @Test
+    public void applyReturnsStringOfDecodedParameters() throws Exception {
+        String encoded = "/parameters?variable_1=Operators%20%3C%2C%20%" +
+            "3E%2C%20%3D%2C%20!%3D%3B%20%2B%2C%20-%2C%20*%2C%20%26%2C%2" +
+            "0%40%2C%20%23%2C%20%24%2C%20%5B%2C%20%5D%3A%20%22is%20that" +
+            "%20all%22%3F&variable_2=stuff";
+
+        Request request = new Request();
+        ParamConverter converter = new ParamConverter();
+
+        request.add("GET /" + encoded + " HTTP/1.1");
+
+        String expectation = "variable_1 = Operators <, >, =, !=; +, -, *," +
+            " &, @, #, $, [, ]: \"is that all\"?" + Server.CRLF +
+            "variable_2 = stuff" + Server.CRLF;
+
+        assertThat(converter.apply(request), is(expectation));
+    }
+}

--- a/src/test/java/duckling/requests/ParamExtractorTest.java
+++ b/src/test/java/duckling/requests/ParamExtractorTest.java
@@ -1,0 +1,36 @@
+package duckling.requests;
+
+import duckling.Server;
+import org.junit.Test;
+
+import java.util.HashMap;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class ParamExtractorTest {
+    @Test
+    public void applyReturnsStringOfDecodedParameters() throws Exception {
+        String encoded = "/parameters?variable_1=Operators%20%3C%2C%20%" +
+            "3E%2C%20%3D%2C%20!%3D%3B%20%2B%2C%20-%2C%20*%2C%20%26%2C%2" +
+            "0%40%2C%20%23%2C%20%24%2C%20%5B%2C%20%5D%3A%20%22is%20that" +
+            "%20all%22%3F&variable_2=stuff";
+
+        Request request = new Request();
+        ParamExtractor extractor = new ParamExtractor();
+
+        request.add("GET /" + encoded + " HTTP/1.1");
+
+        HashMap<String, String> expectation = new HashMap<>();
+
+        expectation.put(
+            "variable_1",
+            "Operators <, >, =, !=; +, -, *, &, @, #, $, [, ]: \"is that all\"?"
+        );
+
+        expectation.put("variable_2", "stuff");
+
+        assertThat(extractor.apply(request), is(expectation));
+    }
+
+}


### PR DESCRIPTION
There was a Route definition which had a pretty complex internal logic
set.  This commit moves that into some intermediate objects which
conform to the same basic interface (`Function<Request, String>`).
These are intermediary, also in the sense that they represent a dabbling
into a potential replacement for the Responders pattern.