### PR TITLE
Clean up pass, use behaviors for redirects.

### DIFF
--- a/src/main/java/duckling/Configuration.java
+++ b/src/main/java/duckling/Configuration.java
@@ -9,17 +9,21 @@ import duckling.routing.Routes;
 import java.util.Arrays;
 
 public class Configuration {
-    public static final int DEFAULT_PORT = 5000;
-    public static final String DEFAULT_ROOT = ".";
+    private static final int DEFAULT_PORT = 5000;
+    private static final String DEFAULT_ROOT = ".";
     public static final RouteDefinitions DEFAULT_ROUTES = new RouteDefinitions(
         Routes.put("/form").with(new StoreMemory()),
         Routes.post("/form").with(new StoreMemory()),
         Routes.get("/form").with(new RetrieveMemory()),
         Routes.delete("/form").with(new EraseMemory()),
-        Routes.get("/redirect").andRedirectTo("/"),
+        Routes.get("/redirect").with(new RedirectTo("/")),
         Routes.get("/parameters").with(new ParamEcho()),
-        Routes.get("/coffee").with(new StaticBody("I'm a teapot"))
-            .andRejectWith(ResponseCodes.TEAPOT),
+        Routes
+            .get("/coffee")
+            .with(
+                new StaticBody("I'm a teapot"),
+                new RespondWith(ResponseCodes.TEAPOT)
+            ),
         Routes.get("/tea").with(new StaticBody("Tea indeed"))
     );
 
@@ -39,7 +43,7 @@ public class Configuration {
         this(port, root, DEFAULT_ROUTES);
     }
 
-    public Configuration(int port, String root, RouteDefinitions routes) {
+    private Configuration(int port, String root, RouteDefinitions routes) {
         this.root = root;
         this.port = port;
         this.routes = routes;

--- a/src/main/java/duckling/Main.java
+++ b/src/main/java/duckling/Main.java
@@ -4,20 +4,20 @@ import duckling.errors.BadArgumentsError;
 
 import java.io.IOException;
 
-public class Main {
-    public static Logger LOGGER = new Logger();
+class Main {
+    private static Logger LOGGER = new Logger();
 
     private Configuration config;
     private Server server;
     private Logger logger;
 
-    public Main(Configuration config) throws IOException {
+    private Main(Configuration config) throws IOException {
         this.config = config;
         this.server = new Server(config);
         this.logger = LOGGER;
     }
 
-    public void start() throws IOException {
+    private void start() throws IOException {
         logger.info(
             String.format("Port: %s", this.config.port),
             String.format("Root: %s", this.config.root)

--- a/src/main/java/duckling/behaviors/DisplayFolder.java
+++ b/src/main/java/duckling/behaviors/DisplayFolder.java
@@ -9,9 +9,9 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public class DisplayFolder implements Behavior {
-    String titleTemplate = "<title>%s</title>";
-    String pageTemplate = "<html><head>%s</head><body>%s</body></html>";
-    String linkTemplate = "<a href=\"%s\">%s</a><br />";
+    private String titleTemplate = "<title>%s</title>";
+    private String pageTemplate = "<html><head>%s</head><body>%s</body></html>";
+    private String linkTemplate = "<a href=\"%s\">%s</a><br />";
 
     @Override
     public Response apply(Request request) {

--- a/src/main/java/duckling/behaviors/EitherBody.java
+++ b/src/main/java/duckling/behaviors/EitherBody.java
@@ -4,8 +4,8 @@ import duckling.requests.Request;
 import duckling.responses.Response;
 
 public class EitherBody implements Behavior {
-    Behavior behavior;
-    boolean shouldHaveBody = true;
+    private Behavior behavior;
+    private boolean shouldHaveBody = true;
 
     public EitherBody(boolean shouldHaveBody, Behavior behavior) {
         this.shouldHaveBody = shouldHaveBody;

--- a/src/main/java/duckling/behaviors/GuessContentType.java
+++ b/src/main/java/duckling/behaviors/GuessContentType.java
@@ -11,7 +11,7 @@ import static java.net.URLConnection.guessContentTypeFromStream;
 public class GuessContentType implements Behavior {
     @Override
     public Response apply(Request request) {
-        return Response.wrap(request).contentType(guessContentType(request.getFile()));
+        return Response.wrap(request).withContentType(guessContentType(request.getFile()));
     }
 
     private String guessContentType(File file) {

--- a/src/main/java/duckling/behaviors/HasOptions.java
+++ b/src/main/java/duckling/behaviors/HasOptions.java
@@ -5,7 +5,7 @@ import duckling.responses.CommonHeaders;
 import duckling.responses.Response;
 
 public class HasOptions implements Behavior {
-    String allowedMethodsString;
+    private String allowedMethodsString;
 
     public HasOptions(String allowedMethodsString) {
         this.allowedMethodsString = allowedMethodsString;
@@ -16,7 +16,7 @@ public class HasOptions implements Behavior {
         Response newResponse = Response.wrap(request);
 
         return request.isOptions() ?
-            newResponse.withHeader(CommonHeaders.ALLOW, allowedMethodsString).withoutBody() :
-            newResponse.contentType("text/html");
+            newResponse.withHeader(CommonHeaders.ALLOW, allowedMethodsString) :
+            newResponse.withContentType("text/html");
     }
 }

--- a/src/main/java/duckling/behaviors/MaybeRouteBody.java
+++ b/src/main/java/duckling/behaviors/MaybeRouteBody.java
@@ -21,9 +21,17 @@ public class MaybeRouteBody implements Behavior {
     public Response apply(Request request) {
         Response response = Response.wrap(request);
         Optional<Route> maybeRoute = routes.getMatch(request);
-        String routeContent = maybeRoute.
-            map(route -> String.format(template, request.getPath(), route.getContent(request))).
-            orElseGet(() -> String.format(template, "", ""));
+        String routeContent =
+            maybeRoute
+                .map(
+                    (route) ->
+                        String.format(
+                            template,
+                            request.getPath(),
+                            response.withBehaviors(route.getBehaviors()).compose().getStringBody()
+                        )
+                )
+                .orElseGet(() -> String.format(template, "", ""));
 
         return response.withBody(routeContent);
     }

--- a/src/main/java/duckling/behaviors/MaybeRouteHeaders.java
+++ b/src/main/java/duckling/behaviors/MaybeRouteHeaders.java
@@ -1,7 +1,6 @@
 package duckling.behaviors;
 
 import duckling.requests.Request;
-import duckling.responses.CommonHeaders;
 import duckling.responses.Response;
 import duckling.responses.ResponseCodes;
 import duckling.routing.Route;
@@ -20,13 +19,18 @@ public class MaybeRouteHeaders implements Behavior {
         Optional<Route> maybeRoute = routes.getMatch(request);
 
         return maybeRoute.
-            map((route) -> route.isRedirect() ?
-                Response.wrap(request)
-                    .respondWith(ResponseCodes.FOUND)
-                    .withHeader(CommonHeaders.LOCATION, route.getContent()) :
-                Response.wrap(request)
-                    .respondWith(route.getResponseCode())
-                    .contentType("text/html")).
-            orElseGet(() -> Response.wrap(request).respondWith(ResponseCodes.NOT_FOUND));
+            map(
+                (route) ->
+                    Response
+                        .wrap(request)
+                        .withBehaviors(route.getBehaviors())
+                        .withContentType("text/html")
+            )
+            .orElseGet(
+                () ->
+                    Response
+                        .wrap(request)
+                        .withResponseCode(ResponseCodes.NOT_FOUND)
+            );
     }
 }

--- a/src/main/java/duckling/behaviors/RedirectTo.java
+++ b/src/main/java/duckling/behaviors/RedirectTo.java
@@ -1,0 +1,22 @@
+package duckling.behaviors;
+
+import duckling.requests.Request;
+import duckling.responses.CommonHeaders;
+import duckling.responses.Response;
+import duckling.responses.ResponseCodes;
+
+public class RedirectTo implements Behavior {
+    private String location;
+
+    public RedirectTo(String location) {
+        this.location = location;
+    }
+
+    @Override
+    public Response apply(Request request) {
+        return Response
+            .wrap(request)
+            .withResponseCode(ResponseCodes.FOUND)
+            .withHeader(CommonHeaders.LOCATION, location);
+    }
+}

--- a/src/main/java/duckling/behaviors/RespondWith.java
+++ b/src/main/java/duckling/behaviors/RespondWith.java
@@ -1,0 +1,18 @@
+package duckling.behaviors;
+
+import duckling.requests.Request;
+import duckling.responses.Response;
+import duckling.responses.ResponseCodes;
+
+public class RespondWith implements Behavior {
+    private ResponseCodes responseCode;
+
+    public RespondWith(ResponseCodes responseCode) {
+        this.responseCode = responseCode;
+    }
+
+    @Override
+    public Response apply(Request request) {
+        return Response.wrap(request).withResponseCode(responseCode);
+    }
+}

--- a/src/main/java/duckling/behaviors/RestrictToMethods.java
+++ b/src/main/java/duckling/behaviors/RestrictToMethods.java
@@ -7,7 +7,7 @@ import duckling.responses.ResponseCodes;
 import java.util.ArrayList;
 
 public class RestrictToMethods implements Behavior {
-    ArrayList<String> allowedMethods;
+    private ArrayList<String> allowedMethods;
 
     public RestrictToMethods(ArrayList<String> allowedMethods) {
         this.allowedMethods = allowedMethods;
@@ -19,6 +19,6 @@ public class RestrictToMethods implements Behavior {
 
         return allowedMethods.contains(request.getMethod()) ?
             newResponse :
-            newResponse.respondWith(ResponseCodes.METHOD_NOT_ALLOWED).contentType("null");
+            newResponse.withResponseCode(ResponseCodes.METHOD_NOT_ALLOWED).withContentType("null");
     }
 }

--- a/src/main/java/duckling/requests/BaseRequest.java
+++ b/src/main/java/duckling/requests/BaseRequest.java
@@ -8,18 +8,18 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public class BaseRequest {
-    public static final String METHOD = "Method";
-    public static final String PATH = "Path";
-    public static final String PROTOCOL = "Protocol";
-    public static final String QUERY = "Query";
-    public static final String EMPTY_PATH = "";
-    public static final String OPTIONS = "OPTIONS";
-    public static final String HEAD = "HEAD";
-    public static final String GET = "GET";
+    private static final String METHOD = "Method";
+    private static final String PATH = "Path";
+    private static final String PROTOCOL = "Protocol";
+    private static final String QUERY = "Query";
+    private static final String EMPTY_PATH = "";
+    private static final String OPTIONS = "OPTIONS";
+    private static final String HEAD = "HEAD";
+    private static final String GET = "GET";
 
-    public static final int METHOD_INDEX = 0;
-    public static final int PATH_INDEX = 1;
-    public static final int PROTOCOL_INDEX = 2;
+    private static final int METHOD_INDEX = 0;
+    private static final int PATH_INDEX = 1;
+    private static final int PROTOCOL_INDEX = 2;
     private static final String DEFAULT_PROTOCOL = "HTTP/1.0";
 
     private Hashtable<String,String> contents = new Hashtable<>();

--- a/src/main/java/duckling/requests/HeaderPair.java
+++ b/src/main/java/duckling/requests/HeaderPair.java
@@ -3,13 +3,13 @@ package duckling.requests;
 import java.util.Arrays;
 import java.util.List;
 
-public class HeaderPair {
+class HeaderPair {
     private static final String KEY_VALUE_SEPARATOR = ": ";
     private static final int KEY_INDEX = 0;
     private static final int VALUE_INDEX = 1;
 
-    public String key = "";
-    public String value = "";
+    private String key = "";
+    private String value = "";
 
     public HeaderPair(String line) {
         List<String> headers = Arrays.asList(line.split(KEY_VALUE_SEPARATOR));

--- a/src/main/java/duckling/requests/QueryParams.java
+++ b/src/main/java/duckling/requests/QueryParams.java
@@ -7,7 +7,7 @@ import java.util.HashMap;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
-public class QueryParams implements Function<Request, HashMap<String, String>> {
+class QueryParams implements Function<Request, HashMap<String, String>> {
     @Override
     public HashMap<String, String> apply(Request request) {
         String query = request.getQuery();

--- a/src/main/java/duckling/requests/Request.java
+++ b/src/main/java/duckling/requests/Request.java
@@ -10,11 +10,11 @@ import java.util.HashMap;
 import java.util.List;
 
 public class Request {
-    protected boolean acceptingBody = false;
+    private boolean acceptingBody = false;
 
-    protected Headers headers = new Headers();
-    protected BaseRequest baseRequest = new BaseRequest();
-    protected ArrayList<String> body = new ArrayList<>();
+    Headers headers = new Headers();
+    private BaseRequest baseRequest = new BaseRequest();
+    private ArrayList<String> body = new ArrayList<>();
 
     private Configuration config;
 

--- a/src/main/java/duckling/requests/RequestHandler.java
+++ b/src/main/java/duckling/requests/RequestHandler.java
@@ -15,7 +15,7 @@ public class RequestHandler implements Runnable {
     private final Logger logger;
     private ArrayList<String> loggables = new ArrayList<>();
 
-    public Request request;
+    private Request request;
 
     public RequestHandler(Socket client, Configuration config) {
         this(client, config, new Logger());

--- a/src/main/java/duckling/responders/NotFound.java
+++ b/src/main/java/duckling/responders/NotFound.java
@@ -19,7 +19,7 @@ public class NotFound extends Responder {
             Response
                 .wrap(givenRequest)
                 .withBody(responseBody)
-                .respondWith(ResponseCodes.NOT_FOUND)
+                .withResponseCode(ResponseCodes.NOT_FOUND)
         );
 
         response.bind(new HasOptions(allowedMethodsString()));

--- a/src/main/java/duckling/responders/Responder.java
+++ b/src/main/java/duckling/responders/Responder.java
@@ -21,11 +21,11 @@ public abstract class Responder {
     }
 
     public InputStream body() {
-        return response.getBody();
+        return response.compose().getBody();
     }
 
     public ArrayList<String> headers() {
-        return response.getResponseHeaders();
+        return response.compose().getResponseHeaders();
     }
 
     public String allowedMethodsString() {
@@ -33,7 +33,7 @@ public abstract class Responder {
     }
 
     public boolean isAllowed() {
-        return this.allowedMethods.contains(this.request.getMethod());
+        return allowedMethods.contains(request.getMethod());
     }
 
     abstract public boolean matches();

--- a/src/main/java/duckling/responders/Responders.java
+++ b/src/main/java/duckling/responders/Responders.java
@@ -18,7 +18,7 @@ public class Responders {
     private Request request;
     private ArrayList<Responder> responders;
 
-    public Responders(Request request, Configuration config) {
+    private Responders(Request request, Configuration config) {
         this(
             request,
             new RoutedContents(request, config),

--- a/src/main/java/duckling/responses/MergeResponse.java
+++ b/src/main/java/duckling/responses/MergeResponse.java
@@ -1,0 +1,34 @@
+package duckling.responses;
+
+import duckling.requests.Request;
+
+import java.util.HashMap;
+
+class MergeResponse {
+    private Response response = new Response(new Request());
+
+    public MergeResponse(Response original) {
+        this.response = original;
+    }
+
+    public Response apply(Response other) {
+        String body = response.responseBody.merge(other.responseBody).body;
+
+        ResponseCodes responseCode =
+            other.responseCode == null ?
+                response.responseCode :
+                other.responseCode;
+
+        HashMap<CommonHeaders, String> headers = new HashMap<>(response.headers);
+
+        other.headers.forEach(headers::put);
+
+        return Response
+            .wrap(other.request)
+            .withBody(body)
+            .withBehaviors(response.behaviors)
+            .withBehaviors(other.behaviors)
+            .withHeaders(headers)
+            .withResponseCode(responseCode);
+    }
+}

--- a/src/main/java/duckling/responses/ResponseBody.java
+++ b/src/main/java/duckling/responses/ResponseBody.java
@@ -1,0 +1,33 @@
+package duckling.responses;
+
+public class ResponseBody {
+    private boolean emptied;
+    String body;
+
+    public ResponseBody(String body) {
+        this(body, false);
+    }
+
+    public ResponseBody(String body, boolean emptied) {
+        this.body = body;
+        this.emptied = emptied;
+    }
+
+    public ResponseBody merge(ResponseBody other) {
+        if (other.wasEmptied()) {
+            return new ResponseBody("");
+        } else if (other.body == null || other.body.isEmpty()) {
+            return new ResponseBody(body);
+        } else {
+            return new ResponseBody(other.body);
+        }
+    }
+
+    public boolean wasEmptied() {
+        return emptied;
+    }
+
+    public byte[] getBytes() {
+        return body.getBytes();
+    }
+}

--- a/src/main/java/duckling/routing/Route.java
+++ b/src/main/java/duckling/routing/Route.java
@@ -3,18 +3,15 @@ package duckling.routing;
 import duckling.behaviors.Behavior;
 import duckling.behaviors.StaticBody;
 import duckling.requests.Request;
-import duckling.responses.ResponseCodes;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.stream.Collectors;
 
 public class Route {
-    protected String routeName;
-    protected String method;
+    private String routeName;
+    private String method;
 
     private ArrayList<Behavior> behaviors;
-    private ResponseCodes responseCode;
 
     public Route() {
         this("GET", "/");
@@ -24,73 +21,40 @@ public class Route {
         this(method, routeName, new StaticBody("not-found"));
     }
 
-    public Route(String method, String routeName, Behavior... behaviors) {
-        this(method, routeName, ResponseCodes.OK, behaviors);
-    }
-
-    public Route(
+    private Route(
         String method,
         String routeName,
-        ResponseCodes responseCode,
         Behavior... behaviors
     ) {
-        this(method, routeName, responseCode, new ArrayList<>());
+        this(method, routeName, new ArrayList<>());
 
         Collections.addAll(this.behaviors, behaviors);
     }
 
-    public Route(
+    private Route(
         String method,
         String routeName,
-        ResponseCodes responseCode,
         ArrayList<Behavior> behaviors
     ) {
         this.method = method;
         this.routeName = routeName.startsWith("/") ? routeName : "/" + routeName;
-        this.responseCode = responseCode;
         this.behaviors = behaviors;
-    }
-
-    public Route andRejectWith(ResponseCodes code) {
-        return new Route(method, routeName, code, behaviors);
-    }
-
-    public Route andRedirectTo(String uri) {
-        return new Route(method, routeName, ResponseCodes.FOUND, new StaticBody(uri));
     }
 
     public Route with(Behavior... pages) {
         return new Route(method, routeName, pages);
     }
 
-    public String getContent(Request request) {
-        return behaviors
-            .stream()
-            .map((page) -> page.apply(request).getStringBody())
-            .collect(Collectors.joining());
-    }
-
-    public String getContent() {
-        return getContent(new Request());
-    }
-
     public boolean hasMethod(String method) {
         return this.method.equals(method);
-    }
-
-    public boolean hasResponder(String routeContents) {
-        return behaviors
-            .stream()
-            .map((page) -> page.apply(new Request()).getStringBody())
-            .anyMatch((string) -> string.equals(routeContents));
     }
 
     public boolean hasRoute(String route) {
         return this.routeName.equals(route);
     }
 
-    public ResponseCodes getResponseCode() {
-        return responseCode;
+    public ArrayList<Behavior> getBehaviors() {
+        return behaviors;
     }
 
     public boolean matches(Request request) {
@@ -116,11 +80,7 @@ public class Route {
 
     @Override
     public String toString() {
-        return method + " " + routeName + " - " + getContent() + " " + responseCode;
-    }
-
-    public boolean isRedirect() {
-        return responseCode.equals(ResponseCodes.FOUND);
+        return method + " " + routeName;
     }
 
 }

--- a/src/main/java/duckling/writers/Writer.java
+++ b/src/main/java/duckling/writers/Writer.java
@@ -6,10 +6,10 @@ import duckling.responders.Responder;
 import java.io.OutputStream;
 
 public abstract class Writer {
-    protected Responder responder;
-    protected OutputStream output;
+    Responder responder;
+    OutputStream output;
 
-    public Writer(Responder responder, OutputStream output) {
+    Writer(Responder responder, OutputStream output) {
         this.responder = responder;
         this.output = output;
     }

--- a/src/test/java/duckling/behaviors/EitherBodyTest.java
+++ b/src/test/java/duckling/behaviors/EitherBodyTest.java
@@ -14,7 +14,7 @@ public class EitherBodyTest {
         EitherBody behavior = new EitherBody(true, new StaticBody("Hey"));
         Response subject = behavior.apply(new Request());
 
-        assertThat(subject.getStringBody(), is("Hey"));
+        assertThat(subject.compose().getStringBody(), is("Hey"));
     }
 
     @Test
@@ -22,7 +22,7 @@ public class EitherBodyTest {
         EitherBody behavior = new EitherBody(false, new StaticBody("Hey"));
         Response subject = behavior.apply(new Request());
 
-        assertThat(subject.getStringBody(), is(equalTo(null)));
+        assertThat(subject.compose().getStringBody(), is(equalTo("")));
     }
 
 }

--- a/src/test/java/duckling/behaviors/MaybeRouteBodyTest.java
+++ b/src/test/java/duckling/behaviors/MaybeRouteBodyTest.java
@@ -21,7 +21,7 @@ public class MaybeRouteBodyTest {
         request.add("GET /hello HTTP/1.1");
 
         assertThat(
-            behavior.apply(request).getStringBody(),
+            behavior.apply(request).compose().getStringBody(),
             is("<html><head><title>/hello</title></head><body>Hey</body></html>")
         );
     }
@@ -35,7 +35,7 @@ public class MaybeRouteBodyTest {
         Behavior behavior = new MaybeRouteBody(definitions);
 
         assertThat(
-            behavior.apply(new Request()).getStringBody(),
+            behavior.apply(new Request()).compose().getStringBody(),
             is("<html><head><title></title></head><body></body></html>")
         );
     }

--- a/src/test/java/duckling/behaviors/MaybeRouteHeadersTest.java
+++ b/src/test/java/duckling/behaviors/MaybeRouteHeadersTest.java
@@ -1,7 +1,6 @@
 package duckling.behaviors;
 
 import duckling.requests.Request;
-import duckling.responses.CommonHeaders;
 import duckling.responses.Response;
 import duckling.responses.ResponseCodes;
 import duckling.routing.RouteDefinitions;
@@ -15,7 +14,7 @@ public class MaybeRouteHeadersTest {
     @Test
     public void suppliesDefinedContentIfGivenMatch() throws Exception {
         RouteDefinitions definitions = new RouteDefinitions(
-            Routes.get("/hello").with(new StaticBody("Hey"))
+            Routes.get("/hello").with(new RespondWith(ResponseCodes.TEAPOT), new StaticBody("Hey"))
         );
 
         Behavior behavior = new MaybeRouteHeaders(definitions);
@@ -24,35 +23,12 @@ public class MaybeRouteHeadersTest {
         request.add("GET /hello HTTP/1.1");
 
         assertThat(
-            behavior.apply(request).getResponseHeaders(),
+            behavior.apply(request).compose().getResponseHeaders(),
             is(
                 Response
                     .wrap(new Request())
-                    .respondWith(ResponseCodes.OK)
-                    .contentType("text/html")
-                    .getResponseHeaders()
-            )
-        );
-    }
-
-    @Test
-    public void suppliesRedirectHeadersWhenDefined() throws Exception {
-        RouteDefinitions definitions = new RouteDefinitions(
-            Routes.get("/redirect").andRedirectTo("/")
-        );
-
-        Behavior behavior = new MaybeRouteHeaders(definitions);
-
-        Request request = new Request();
-        request.add("GET /redirect HTTP/1.1");
-
-        assertThat(
-            behavior.apply(request).getResponseHeaders(),
-            is(
-                Response
-                    .wrap(new Request())
-                    .respondWith(ResponseCodes.FOUND)
-                    .withHeader(CommonHeaders.LOCATION, "/")
+                    .withResponseCode(ResponseCodes.TEAPOT)
+                    .withContentType("text/html")
                     .getResponseHeaders()
             )
         );
@@ -71,7 +47,7 @@ public class MaybeRouteHeadersTest {
             is(
                 Response
                     .wrap(new Request())
-                    .respondWith(ResponseCodes.NOT_FOUND)
+                    .withResponseCode(ResponseCodes.NOT_FOUND)
                     .getResponseHeaders()
             )
         );

--- a/src/test/java/duckling/behaviors/ParamEchoTest.java
+++ b/src/test/java/duckling/behaviors/ParamEchoTest.java
@@ -25,6 +25,6 @@ public class ParamEchoTest {
             " &, @, #, $, [, ]: \"is that all\"?" + Server.CRLF +
             "variable_2 = stuff" + Server.CRLF;
 
-        assertThat(converter.apply(request).getStringBody(), is(expectation));
+        assertThat(converter.apply(request).compose().getStringBody(), is(expectation));
     }
 }

--- a/src/test/java/duckling/behaviors/RestrictToMethodsTest.java
+++ b/src/test/java/duckling/behaviors/RestrictToMethodsTest.java
@@ -19,7 +19,7 @@ public class RestrictToMethodsTest {
         Behavior behavior = new RestrictToMethods(methods);
         Response subject = behavior.apply(new Request());
 
-        assertThat(subject.getResponseCode(), is(ResponseCodes.METHOD_NOT_ALLOWED));
+        assertThat(subject.compose().responseCode, is(ResponseCodes.METHOD_NOT_ALLOWED));
     }
 
     @Test

--- a/src/test/java/duckling/behaviors/RetrieveMemoryTest.java
+++ b/src/test/java/duckling/behaviors/RetrieveMemoryTest.java
@@ -24,7 +24,7 @@ public class RetrieveMemoryTest {
 
         request.add("GET / HTTP/1.1");
 
-        assertThat(behavior.apply(request).getStringBody(), is(expectation));
+        assertThat(behavior.apply(request).compose().getStringBody(), is(expectation));
     }
 
     @Test
@@ -37,6 +37,6 @@ public class RetrieveMemoryTest {
 
         request.add("GET /form HTTP/1.1");
 
-        assertThat(behavior.apply(request).getStringBody(), is(""));
+        assertThat(behavior.apply(request).compose().getStringBody(), is(""));
     }
 }

--- a/src/test/java/duckling/requests/RequestHandlerTest.java
+++ b/src/test/java/duckling/requests/RequestHandlerTest.java
@@ -124,8 +124,8 @@ public class RequestHandlerTest {
         String response =
             Response
                 .wrap(new Request())
-                .respondWith(ResponseCodes.NOT_FOUND)
-                .contentType("text/html")
+                .withResponseCode(ResponseCodes.NOT_FOUND)
+                .withContentType("text/html")
                 .getResponseHeaders()
                 .stream()
                 .collect(Collectors.joining());

--- a/src/test/java/duckling/responders/FileContentsTest.java
+++ b/src/test/java/duckling/responders/FileContentsTest.java
@@ -99,7 +99,7 @@ public class FileContentsTest {
         ArrayList<String> headers =
             Response
                 .wrap(request)
-                .contentType("text/plain")
+                .withContentType("text/plain")
                 .getResponseHeaders();
 
         assertThat(responder.headers(), is(headers));
@@ -129,8 +129,8 @@ public class FileContentsTest {
         ArrayList<String> headers =
             Response
                 .wrap(request)
-                .respondWith(ResponseCodes.METHOD_NOT_ALLOWED)
-                .contentType("null")
+                .withResponseCode(ResponseCodes.METHOD_NOT_ALLOWED)
+                .withContentType("null")
                 .getResponseHeaders();
 
         assertThat(responder.headers(), is(headers));

--- a/src/test/java/duckling/responders/FolderContentsTest.java
+++ b/src/test/java/duckling/responders/FolderContentsTest.java
@@ -80,7 +80,7 @@ public class FolderContentsTest {
         ArrayList<String> headers =
             Response
                 .wrap(request)
-                .contentType("text/html")
+                .withContentType("text/html")
                 .getResponseHeaders();
 
         assertThat(responder.headers(), is(headers));
@@ -111,8 +111,8 @@ public class FolderContentsTest {
         ArrayList<String> headers =
             Response
                 .wrap(request)
-                .respondWith(ResponseCodes.METHOD_NOT_ALLOWED)
-                .contentType("null")
+                .withResponseCode(ResponseCodes.METHOD_NOT_ALLOWED)
+                .withContentType("null")
                 .getResponseHeaders();
 
         assertThat(responder.headers(), is(headers));

--- a/src/test/java/duckling/responders/NotFoundTest.java
+++ b/src/test/java/duckling/responders/NotFoundTest.java
@@ -38,7 +38,7 @@ public class NotFoundTest {
         ArrayList<String> headers =
             Response
                 .wrap(request)
-                .respondWith(ResponseCodes.NOT_FOUND)
+                .withResponseCode(ResponseCodes.NOT_FOUND)
                 .withHeader(CommonHeaders.ALLOW, responder.allowedMethodsString())
                 .getResponseHeaders();
 
@@ -50,8 +50,8 @@ public class NotFoundTest {
         ArrayList<String> headers =
             Response
                 .wrap(new Request())
-                .respondWith(ResponseCodes.NOT_FOUND)
-                .contentType("text/html")
+                .withResponseCode(ResponseCodes.NOT_FOUND)
+                .withContentType("text/html")
                 .getResponseHeaders();
 
         assertThat(responder.headers(), is(headers));
@@ -68,9 +68,7 @@ public class NotFoundTest {
 
         int input;
 
-        while ((input = inputStream.read()) != -1) {
-            outputStream.write(input);
-        }
+        while ((input = inputStream.read()) != -1) outputStream.write(input);
 
         assertThat(outputStream.getWrittenOutput(), is(expectation));
     }

--- a/src/test/java/duckling/responses/MergeResponseTest.java
+++ b/src/test/java/duckling/responses/MergeResponseTest.java
@@ -1,0 +1,98 @@
+package duckling.responses;
+
+import duckling.behaviors.RespondWith;
+import duckling.behaviors.StaticBody;
+import duckling.requests.Request;
+import org.junit.Test;
+
+import java.util.HashMap;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class MergeResponseTest {
+
+    @Test
+    public void replacesResponseBody() {
+        Response original = Response.wrap(new Request()).withBody("Hey,");
+        Response other = Response.wrap(new Request()).withBody(" you!");
+        MergeResponse merge = new MergeResponse(original);
+
+        assertThat(merge.apply(other).compose().getStringBody(), is(" you!"));
+    }
+
+    @Test
+    public void replacesResponseCode() {
+        Response original = Response.wrap(new Request()).withResponseCode(ResponseCodes.NOT_FOUND);
+        Response other = Response.wrap(new Request()).withResponseCode(ResponseCodes.FOUND);
+        MergeResponse merge = new MergeResponse(original);
+
+        assertThat(merge.apply(other).compose().responseCode, is(ResponseCodes.FOUND));
+    }
+
+    @Test
+    public void combinesHeaders() {
+        HashMap<CommonHeaders, String> expectation = new HashMap<>();
+        Response original = Response.wrap(new Request()).withHeader(CommonHeaders.LOCATION, "/here");
+        Response other = Response.wrap(new Request()).withHeader(CommonHeaders.ALLOW, "GET");
+        MergeResponse merge = new MergeResponse(original);
+
+        expectation.put(CommonHeaders.LOCATION, "/here");
+        expectation.put(CommonHeaders.ALLOW, "GET");
+
+        assertThat(
+            merge.apply(other).getHeaders(),
+            is(expectation)
+        );
+    }
+
+    @Test
+    public void replacesRepeatedHeaders() {
+        HashMap<CommonHeaders, String> expectation = new HashMap<>();
+        Response original = Response.wrap(new Request()).withHeader(CommonHeaders.LOCATION, "/here");
+        Response other = Response.wrap(new Request()).withHeader(CommonHeaders.LOCATION, "/there");
+        MergeResponse merge = new MergeResponse(original);
+
+        expectation.put(CommonHeaders.LOCATION, "/there");
+
+        assertThat(
+            merge.apply(other).getHeaders(),
+            is(expectation)
+        );
+    }
+
+    @Test
+    public void combinesBehaviors() {
+        Response original = Response.wrap(new Request());
+        Response other = Response.wrap(new Request());
+
+        original.bind(new StaticBody("Hey hey."));
+        other.bind(new RespondWith(ResponseCodes.NOT_FOUND));
+
+        MergeResponse merge = new MergeResponse(original);
+
+        assertThat(
+            merge.apply(other).behaviors.size(),
+            is(2)
+        );
+    }
+
+    @Test
+    public void replacesRequests() {
+        Request originalRequest = new Request();
+        Request otherRequest = new Request();
+
+        originalRequest.add("GET / HTTP/1.1");
+        otherRequest.add("GET /different-path HTTP/1.1");
+
+        Response original = Response.wrap(originalRequest);
+        Response other = Response.wrap(otherRequest);
+        MergeResponse merge = new MergeResponse(original);
+
+        assertThat(
+            merge.apply(other).request,
+            is(otherRequest)
+        );
+    }
+
+}

--- a/src/test/java/duckling/routing/RouteTest.java
+++ b/src/test/java/duckling/routing/RouteTest.java
@@ -1,8 +1,6 @@
 package duckling.routing;
 
-import duckling.behaviors.StaticBody;
 import duckling.requests.Request;
-import duckling.responses.ResponseCodes;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -16,30 +14,6 @@ public class RouteTest {
     public void hasDefaultRoute() throws Exception {
         Route route = new Route();
         assertThat(route.hasRoute("/"), is(true));
-    }
-
-    @Test
-    public void hasDefaultResponder() throws Exception {
-        Route route = new Route();
-        assertThat(route.hasResponder("not-found"), is(true));
-    }
-
-    @Test
-    public void assignsResponderUsingWith() throws Exception {
-        Route route = new Route().with(new StaticBody("supercool"));
-        assertThat(route.hasResponder("supercool"), is(true));
-    }
-
-    @Test
-    public void isRedirectReturnsTrueWhenIsRedirect() throws Exception {
-        Route route = new Route().andRedirectTo("/anywhere");
-        assertThat(route.isRedirect(), is(true));
-    }
-
-    @Test
-    public void isRedirectReturnsFalseWhenIsNotRedirect() throws Exception {
-        Route route = new Route();
-        assertThat(route.isRedirect(), is(false));
     }
 
     @Test
@@ -90,19 +64,6 @@ public class RouteTest {
         request.add("GET / HTTP/1.1");
 
         assertThat(route.matches(request), is(not(true)));
-    }
-
-    @Test
-    public void hasDefaultResponseCode() {
-        assertThat(Routes.get().getResponseCode(), is(ResponseCodes.OK));
-    }
-
-    @Test
-    public void acceptsRejectionCodes() {
-        Route route = Routes.get("/coffee")
-            .andRejectWith(ResponseCodes.TEAPOT);
-
-        assertThat(route.getResponseCode(), is(ResponseCodes.TEAPOT));
     }
 
 }

--- a/src/test/java/duckling/support/SpyResponder.java
+++ b/src/test/java/duckling/support/SpyResponder.java
@@ -23,7 +23,7 @@ public class SpyResponder extends Responder {
         this(new Request());
     }
 
-    public SpyResponder(Request request) {
+    private SpyResponder(Request request) {
         super(request);
     }
 

--- a/src/test/java/duckling/support/SpyThreadPool.java
+++ b/src/test/java/duckling/support/SpyThreadPool.java
@@ -11,17 +11,13 @@ public class SpyThreadPool extends ThreadPoolExecutor {
     private List<Runnable> threads = new ArrayList<>();
 
     public SpyThreadPool() {
-        this(1, 1, 1, TimeUnit.SECONDS, new SynchronousQueue<>());
+        this(new SynchronousQueue<>());
     }
 
-    public SpyThreadPool(
-        int corePoolSize,
-        int maximumPoolSize,
-        long keepAliveTime,
-        TimeUnit unit,
+    private SpyThreadPool(
         BlockingQueue<Runnable> workQueue
     ) {
-        super(corePoolSize, maximumPoolSize, keepAliveTime, unit, workQueue);
+        super(1, 1, (long) 1, TimeUnit.SECONDS, workQueue);
     }
 
     @Override


### PR DESCRIPTION
Although it's kind of a big commit, the driving point behind this commit
was cleaning things up a bit.  We're going to rely on Route objects for
a whole lot less, for example - they no longer generate content or any
of that.  Really, they just map a list of behaviors to a method / route
combo now.

There was a bit of extra logic involved in merging responses, however,
so there is a new pair of objects in charge of that. MergeResponses
handles the merge itself, and ResponseBody wraps the string merge / body
wipe logic.  Eventually ResponseBody ought to help with ranges, as well.

Finally, it turned out that (although "clever"), the approach I was using to
compose responses was pretty slow.  Basically, I was composing responses
and rolling them up level by level.  A merge candidate would be composed
entirely before being merged into a target Response.

It was leading to tons of looping, but also it was creating a good
amount of strange bugs, and opening the application up to the
possibility of infinite loops if there were any self-referential
Behavior objects in a composition web.

The new approach to merging simply concatenates behavior lists, which is
faster, less complicated and coincidentally still does the trick
perfectly.