### PR TITLE
Add cookie support tools.

### DIFF
--- a/src/main/java/duckling/Configuration.java
+++ b/src/main/java/duckling/Configuration.java
@@ -18,6 +18,11 @@ public class Configuration {
         Routes.delete("/form").with(new EraseMemory()),
         Routes.get("/redirect").with(new RedirectTo("/")),
         Routes.get("/parameters").with(new ParamEcho()),
+        Routes.get("/cookie").with(
+            new SetCookieFromParam("type"),
+            new StaticBody("Eat")
+        ),
+        Routes.get("/eat_cookie").with(new YummyTastyCookie("type")),
         Routes
             .get("/coffee")
             .with(

--- a/src/main/java/duckling/behaviors/SetCookie.java
+++ b/src/main/java/duckling/behaviors/SetCookie.java
@@ -1,0 +1,22 @@
+package duckling.behaviors;
+
+import duckling.requests.Request;
+import duckling.responses.CommonHeaders;
+import duckling.responses.Response;
+
+public class SetCookie implements Behavior {
+    String key;
+    String value;
+
+    public SetCookie(String key, String value) {
+        this.key = key;
+        this.value = value;
+    }
+
+    @Override
+    public Response apply(Request request) {
+        return Response
+            .wrap(request)
+            .withHeader(CommonHeaders.SET_COOKIE, key + "=" + value);
+    }
+}

--- a/src/main/java/duckling/behaviors/SetCookieFromParam.java
+++ b/src/main/java/duckling/behaviors/SetCookieFromParam.java
@@ -1,0 +1,19 @@
+package duckling.behaviors;
+
+import duckling.requests.Request;
+import duckling.responses.Response;
+
+public class SetCookieFromParam implements Behavior {
+    String key;
+
+    public SetCookieFromParam(String key) {
+        this.key = key;
+    }
+
+    @Override
+    public Response apply(Request request) {
+        String value = request.getParams().getOrDefault(key, "");
+
+        return new SetCookie(key, value).apply(request);
+    }
+}

--- a/src/main/java/duckling/behaviors/YummyTastyCookie.java
+++ b/src/main/java/duckling/behaviors/YummyTastyCookie.java
@@ -1,0 +1,27 @@
+package duckling.behaviors;
+
+import duckling.requests.Request;
+import duckling.responses.Response;
+
+public class YummyTastyCookie implements Behavior {
+    String key;
+
+    public YummyTastyCookie(String key) {
+        this.key = key;
+    }
+
+    @Override
+    public Response apply(Request request) {
+        Response response = Response.wrap(request);
+        String[] flavorPair = request.headers.get("Cookie").split("=");
+        String notFound = "Doesn't taste like anything to me.";
+
+        try {
+            return key.equals(flavorPair[0]) ?
+                response.withBody("mmmm " + flavorPair[1]) :
+                response.withBody(notFound);
+        } catch (ArrayIndexOutOfBoundsException exception) {
+            return Response.wrap(request).withBody(notFound);
+        }
+    }
+}

--- a/src/main/java/duckling/requests/Request.java
+++ b/src/main/java/duckling/requests/Request.java
@@ -10,9 +10,9 @@ import java.util.HashMap;
 import java.util.List;
 
 public class Request {
-    private boolean acceptingBody = false;
+    public Headers headers = new Headers();
 
-    Headers headers = new Headers();
+    private boolean acceptingBody = false;
     private BaseRequest baseRequest = new BaseRequest();
     private ArrayList<String> body = new ArrayList<>();
 

--- a/src/main/java/duckling/responses/CommonHeaders.java
+++ b/src/main/java/duckling/responses/CommonHeaders.java
@@ -3,7 +3,8 @@ package duckling.responses;
 public enum CommonHeaders {
     CONTENT_TYPE ("Content-Type"),
     LOCATION     ("Location"),
-    ALLOW        ("Allow");
+    ALLOW        ("Allow"),
+    SET_COOKIE   ("Set-Cookie");
 
     final String name;
 

--- a/src/test/java/duckling/behaviors/SetCookieFromParamTest.java
+++ b/src/test/java/duckling/behaviors/SetCookieFromParamTest.java
@@ -1,0 +1,32 @@
+package duckling.behaviors;
+
+import duckling.requests.Request;
+import duckling.responses.CommonHeaders;
+import duckling.responses.Response;
+import org.junit.Test;
+
+import java.util.ArrayList;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class SetCookieFromParamTest {
+    @Test
+    public void configuresSetCookieHeaderFromRequestParams() throws Exception {
+        Request request = new Request();
+        String key = "stuff";
+        String value = "things";
+        Behavior behavior = new SetCookieFromParam(key);
+
+        request.add("GET /?" + key + "=" + value + " HTTP1.1");
+
+        Response subject = behavior.apply(request);
+        ArrayList<String> expectation =
+            Response
+                .wrap(request)
+                .withHeader(CommonHeaders.SET_COOKIE, key + "=" + value)
+                .getResponseHeaders();
+
+        assertThat(subject.getResponseHeaders(), is(expectation));
+    }
+}

--- a/src/test/java/duckling/behaviors/SetCookieTest.java
+++ b/src/test/java/duckling/behaviors/SetCookieTest.java
@@ -1,0 +1,27 @@
+package duckling.behaviors;
+
+import duckling.requests.Request;
+import duckling.responses.CommonHeaders;
+import duckling.responses.Response;
+import org.junit.Test;
+
+import java.util.ArrayList;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class SetCookieTest {
+    @Test
+    public void addsSetCookieHeaderToResponse() throws Exception {
+        String key = "stuff";
+        String value = "things";
+        Response subject = new SetCookie(key, value).apply(new Request());
+        ArrayList<String> expectation =
+            Response
+                .wrap(new Request())
+                .withHeader(CommonHeaders.SET_COOKIE, key + "=" + value)
+                .getResponseHeaders();
+
+        assertThat(subject.getResponseHeaders(), is(expectation));
+    }
+}

--- a/src/test/java/duckling/behaviors/YummyTastyCookieTest.java
+++ b/src/test/java/duckling/behaviors/YummyTastyCookieTest.java
@@ -1,0 +1,69 @@
+package duckling.behaviors;
+
+import duckling.requests.Request;
+import duckling.responses.Response;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class YummyTastyCookieTest {
+    @Test
+    public void whatDoesThisTasteLikeToYou() throws Exception {
+        Response response = new YummyTastyCookie("type").apply(new Request());
+        String expectation = "Doesn't taste like anything to me.";
+
+        assertThat(response.getStringBody(), is(expectation));
+    }
+
+    @Test
+    public void reportsFlavorWhenGivenOne() throws Exception {
+        Request request = new Request();
+        String key = "flavor";
+        String value = "vanilla";
+        Behavior behavior = new YummyTastyCookie(key);
+
+        request.add(
+            "GET / HTTP/1.1",
+            "Cookie: " + key + "=" + value
+        );
+
+        Response subject = behavior.apply(request);
+
+        assertThat(subject.getStringBody(), is("mmmm " + value));
+    }
+
+    @Test
+    public void ignoresBadValues() throws Exception {
+        Request request = new Request();
+        String key = "flavor";
+        Behavior behavior = new YummyTastyCookie(key);
+        String expectation = "Doesn't taste like anything to me.";
+
+        request.add(
+            "GET / HTTP/1.1",
+            "Cookie: " + key + "="
+        );
+
+        Response subject = behavior.apply(request);
+
+        assertThat(subject.getStringBody(), is(expectation));
+    }
+
+    @Test
+    public void ignoresBadKeys() throws Exception {
+        Request request = new Request();
+        Behavior behavior = new YummyTastyCookie("flavor");
+        String expectation = "Doesn't taste like anything to me.";
+
+        request.add(
+            "GET / HTTP/1.1",
+            "Cookie: type=vanilla"
+        );
+
+        Response subject = behavior.apply(request);
+
+        assertThat(subject.getStringBody(), is(expectation));
+    }
+
+}


### PR DESCRIPTION
This commit adds cookie support and demonstrates its use on a few
routes.  Pretty cool moment, actually, in that I was able to deliver
this feature just by adding a few simple-to-implement behavior objects.
Smug time!