### PR TITLE
Add basic authentication support.

### DIFF
--- a/src/main/java/duckling/Configuration.java
+++ b/src/main/java/duckling/Configuration.java
@@ -22,6 +22,9 @@ public class Configuration {
             new SetCookieFromParam("type"),
             new StaticBody("Eat")
         ),
+        Routes
+            .get("/logs")
+            .with(new HasBasicAuth("admin", "hunter2")),
         Routes.get("/eat_cookie").with(new YummyTastyCookie("type")),
         Routes
             .get("/coffee")

--- a/src/main/java/duckling/behaviors/HasBasicAuth.java
+++ b/src/main/java/duckling/behaviors/HasBasicAuth.java
@@ -1,0 +1,39 @@
+package duckling.behaviors;
+
+import duckling.requests.Request;
+import duckling.responses.CommonHeaders;
+import duckling.responses.Response;
+import duckling.responses.ResponseCodes;
+
+import java.util.Base64;
+
+public class HasBasicAuth implements Behavior {
+    String username;
+    String password;
+    String target;
+
+    public HasBasicAuth(String username, String password) {
+        this.username = username;
+        this.password = password;
+        this.target = username + ":" + password;
+    }
+
+    @Override
+    public Response apply(Request request) {
+        Response response = Response.wrap(request);
+        String[] authPair = request.headers.get("Authorization").split(" ");
+        Response denied = response
+            .withResponseCode(ResponseCodes.ACCESS_DENIED)
+            .withHeader(CommonHeaders.AUTHENTICATE, "Basic realm=\"duckling\"");
+
+        try {
+            String credentials = authPair[1];
+            String target = new String(Base64.getEncoder().encode(this.target.getBytes()));
+
+            return credentials.equals(target) ? response : denied;
+        } catch (ArrayIndexOutOfBoundsException exception) {
+            return denied;
+        }
+
+    }
+}

--- a/src/main/java/duckling/responses/CommonHeaders.java
+++ b/src/main/java/duckling/responses/CommonHeaders.java
@@ -4,7 +4,8 @@ public enum CommonHeaders {
     CONTENT_TYPE ("Content-Type"),
     LOCATION     ("Location"),
     ALLOW        ("Allow"),
-    SET_COOKIE   ("Set-Cookie");
+    SET_COOKIE   ("Set-Cookie"),
+    AUTHENTICATE ("WWW-Authenticate");
 
     final String name;
 

--- a/src/main/java/duckling/responses/ResponseCodes.java
+++ b/src/main/java/duckling/responses/ResponseCodes.java
@@ -5,7 +5,8 @@ public enum ResponseCodes {
     NOT_FOUND          (404, "NOT FOUND"),
     TEAPOT             (418, "TEAPOT"),
     METHOD_NOT_ALLOWED (405, "METHOD NOT ALLOWED"),
-    FOUND              (302, "FOUND");
+    FOUND              (302, "FOUND"),
+    ACCESS_DENIED      (401, "ACCESS DENIED");
 
     final int status;
     final String message;

--- a/src/test/java/duckling/behaviors/HasBasicAuthTest.java
+++ b/src/test/java/duckling/behaviors/HasBasicAuthTest.java
@@ -1,0 +1,78 @@
+package duckling.behaviors;
+
+import duckling.requests.Request;
+import duckling.responses.CommonHeaders;
+import duckling.responses.Response;
+import duckling.responses.ResponseCodes;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Base64;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class HasBasicAuthTest {
+    @Test
+    public void defaultsToAccessDeniedResponse() throws Exception {
+        Behavior behavior = new HasBasicAuth("admin", "pass");
+        Response subject = behavior.apply(new Request()) ;
+
+        ArrayList<String> expectation =
+            Response
+                .wrap(new Request())
+                .withResponseCode(ResponseCodes.ACCESS_DENIED)
+                .withHeader(CommonHeaders.AUTHENTICATE, "Basic realm=\"duckling\"")
+                .getResponseHeaders();
+
+        assertThat(subject.getResponseHeaders(), is(expectation));
+    }
+
+    @Test
+    public void permitsResponseOnGoodCredentials() throws Exception {
+        Behavior behavior = new HasBasicAuth("admin", "pass");
+        Request request = new Request();
+        String credentials = new String(
+            Base64.getEncoder().encode("admin:pass".getBytes())
+        );
+
+        request.add(
+            "GET / HTTP/1.1",
+            "Authorization: Basic " + credentials
+        );
+
+        Response subject = behavior.apply(request);
+
+        ArrayList<String> expectation =
+            Response
+                .wrap(new Request())
+                .withHeader(CommonHeaders.AUTHENTICATE, "Basic realm=\"duckling\"")
+                .getResponseHeaders();
+
+        assertThat(subject.getResponseHeaders(), is(expectation));
+    }
+
+    @Test
+    public void deniesResponseOnBadCredentials() throws Exception {
+        Behavior behavior = new HasBasicAuth("admin", "pass");
+        Request request = new Request();
+
+        request.add(
+            "GET / HTTP/1.1",
+            "Authorization: Basic arglebargle"
+        );
+
+        Response subject = behavior.apply(request);
+
+        ArrayList<String> expectation =
+            Response
+                .wrap(new Request())
+                .withResponseCode(ResponseCodes.ACCESS_DENIED)
+                .withHeader(CommonHeaders.AUTHENTICATE, "Basic realm=\"duckling\"")
+                .getResponseHeaders();
+
+        assertThat(subject.getResponseHeaders(), is(expectation));
+    }
+
+
+}

--- a/src/test/java/duckling/behaviors/YummyTastyCookieTest.java
+++ b/src/test/java/duckling/behaviors/YummyTastyCookieTest.java
@@ -8,6 +8,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 public class YummyTastyCookieTest {
+
     @Test
     public void whatDoesThisTasteLikeToYou() throws Exception {
         Response response = new YummyTastyCookie("type").apply(new Request());


### PR DESCRIPTION
This commit introduces basic authentication behavior.  Although it only
accepts username and password currently, it works wonderfully.  It
should probably take a realm entry as well, don't you think?  That's not
in our specification right now but maybe one day.