### PR TITLE
Allow partial content requests for files.

### DIFF
--- a/src/main/java/duckling/behaviors/DisplayFile.java
+++ b/src/main/java/duckling/behaviors/DisplayFile.java
@@ -1,0 +1,26 @@
+package duckling.behaviors;
+
+import duckling.requests.Request;
+import duckling.responses.Response;
+
+import java.io.BufferedInputStream;
+import java.io.ByteArrayInputStream;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+
+public class DisplayFile implements Behavior {
+    @Override
+    public Response apply(Request request) {
+        Response response = Response.wrap(request);
+
+        try {
+            return response.withStreamBody(
+                new BufferedInputStream(
+                    new FileInputStream(request.getFile().getAbsoluteFile())
+                )
+            );
+        } catch (FileNotFoundException exception) {
+            return response.withStreamBody(new ByteArrayInputStream("".getBytes()));
+        }
+    }
+}

--- a/src/main/java/duckling/behaviors/PartialContent.java
+++ b/src/main/java/duckling/behaviors/PartialContent.java
@@ -1,0 +1,86 @@
+package duckling.behaviors;
+
+import duckling.requests.Request;
+import duckling.responses.ResponseBodyFilter;
+import duckling.responses.Response;
+import duckling.responses.ResponseCodes;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+
+public class PartialContent implements Behavior {
+
+    @Override
+    public Response apply(Request request) {
+        String rawRange = request.headers.get("Range");
+        Response response = Response.wrap(request);
+
+        if (rawRange.isEmpty()) return Response.wrap(request);
+
+        ResponseBodyFilter responseBodyFilter = (givenResponse) -> {
+            try {
+                byte[] content;
+                Range range = new Range(rawRange);
+
+                if (range.noDefinedEnd()) {
+                    content = givenResponse.responseBody.getBytes(range.from());
+                } else if (range.noDefinedStart()) {
+                    content = givenResponse.responseBody.getBytes(
+                        givenResponse.responseBody.getBytes().length - range.to()
+                    );
+                } else {
+                    content = givenResponse.responseBody.getBytes(range.from(), range.to());
+                }
+
+                InputStream stream = new ByteArrayInputStream(content);
+
+                return givenResponse.withStreamBody(stream);
+            } catch (IndexOutOfBoundsException exception) {
+                return givenResponse.withResponseCode(ResponseCodes.BAD_REQUEST);
+            }
+        };
+
+        return response
+            .withResponseCode(ResponseCodes.PARTIAL_CONTENT)
+            .withResponseBodyFilter(responseBodyFilter);
+    }
+
+    class ParseIntWithDefault {
+        public Integer apply(String string, Integer givenDefault) {
+            return string == null || string.isEmpty() ? givenDefault : Integer.parseInt(string);
+        }
+    }
+
+    class Range {
+        String raw;
+        ArrayList<String> values;
+
+        Range(String rawRange) {
+            ArrayList<String> rangePair = new ArrayList(Arrays.asList(rawRange.split("=")));
+
+            this.raw = rawRange;
+            this.values = new ArrayList(Arrays.asList(rangePair.get(1).split("-", 2)));
+        }
+
+        public Integer from() {
+            ParseIntWithDefault parseInt = new ParseIntWithDefault();
+            return parseInt.apply(values.get(0), -1);
+        }
+
+        public Integer to() {
+            ParseIntWithDefault parseInt = new ParseIntWithDefault();
+            return parseInt.apply(values.get(1), -1);
+        }
+
+        public boolean noDefinedEnd() {
+            return to() == -1;
+        }
+
+        public boolean noDefinedStart() {
+            return from() == -1;
+        }
+    }
+
+}

--- a/src/main/java/duckling/responders/FileContents.java
+++ b/src/main/java/duckling/responders/FileContents.java
@@ -1,8 +1,6 @@
 package duckling.responders;
 
-import duckling.behaviors.GuessContentType;
-import duckling.behaviors.HasOptions;
-import duckling.behaviors.RestrictToMethods;
+import duckling.behaviors.*;
 import duckling.requests.Request;
 
 import java.io.*;
@@ -18,17 +16,8 @@ public class FileContents extends Responder {
         response.bind(new HasOptions(allowedMethodsString()));
         response.bind(new RestrictToMethods(allowedMethods));
         response.bind(new GuessContentType());
-    }
-
-    @Override
-    public InputStream body() {
-        try {
-            return new BufferedInputStream(
-                new FileInputStream(this.file.getAbsoluteFile())
-            );
-        } catch (FileNotFoundException exception) {
-            return new ByteArrayInputStream("".getBytes());
-        }
+        response.bind(new DisplayFile());
+        response.bind(new PartialContent());
     }
 
     @Override

--- a/src/main/java/duckling/responders/Responder.java
+++ b/src/main/java/duckling/responders/Responder.java
@@ -1,5 +1,6 @@
 package duckling.responders;
 
+import duckling.Server;
 import duckling.requests.Request;
 import duckling.responses.Response;
 

--- a/src/main/java/duckling/responses/MergeResponse.java
+++ b/src/main/java/duckling/responses/MergeResponse.java
@@ -12,7 +12,7 @@ class MergeResponse {
     }
 
     public Response apply(Response other) {
-        String body = response.responseBody.merge(other.responseBody).body;
+        ResponseBody responseBody = response.responseBody.merge(other.responseBody);
 
         ResponseCodes responseCode =
             other.responseCode == null ?
@@ -25,9 +25,11 @@ class MergeResponse {
 
         return Response
             .wrap(other.request)
-            .withBody(body)
+            .withResponseBody(responseBody)
             .withBehaviors(response.behaviors)
             .withBehaviors(other.behaviors)
+            .withResponseBodyFilters(response.responseBodyFilters)
+            .withResponseBodyFilters(other.responseBodyFilters)
             .withHeaders(headers)
             .withResponseCode(responseCode);
     }

--- a/src/main/java/duckling/responses/ResponseBodyFilter.java
+++ b/src/main/java/duckling/responses/ResponseBodyFilter.java
@@ -1,0 +1,5 @@
+package duckling.responses;
+
+public interface ResponseBodyFilter {
+    Response apply(Response response);
+}

--- a/src/main/java/duckling/responses/ResponseCodes.java
+++ b/src/main/java/duckling/responses/ResponseCodes.java
@@ -1,12 +1,14 @@
 package duckling.responses;
 
 public enum ResponseCodes {
-    OK                 (200, "OK"),
-    NOT_FOUND          (404, "NOT FOUND"),
-    TEAPOT             (418, "TEAPOT"),
-    METHOD_NOT_ALLOWED (405, "METHOD NOT ALLOWED"),
-    FOUND              (302, "FOUND"),
-    ACCESS_DENIED      (401, "ACCESS DENIED");
+    OK                    (200, "OK"),
+    PARTIAL_CONTENT       (206, "PARTIAL CONTENT"),
+    FOUND                 (302, "FOUND"),
+    BAD_REQUEST           (400, "BAD REQUEST"),
+    ACCESS_DENIED         (401, "ACCESS DENIED"),
+    NOT_FOUND             (404, "NOT FOUND"),
+    METHOD_NOT_ALLOWED    (405, "METHOD NOT ALLOWED"),
+    TEAPOT                (418, "TEAPOT");
 
     final int status;
     final String message;

--- a/src/test/java/duckling/behaviors/DisplayFileTest.java
+++ b/src/test/java/duckling/behaviors/DisplayFileTest.java
@@ -1,0 +1,23 @@
+package duckling.behaviors;
+
+import duckling.requests.Request;
+import duckling.responses.Response;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class DisplayFileTest {
+    @Test
+    public void apply() throws Exception {
+        Request request = new Request();
+        Behavior behavior = new DisplayFile();
+
+        request.add("GET /file.txt HTTP/1.1");
+
+        Response subject = behavior.apply(request);
+
+        assertThat(subject.responseBody.isStream(), is(true));
+    }
+
+}

--- a/src/test/java/duckling/behaviors/PartialContentTest.java
+++ b/src/test/java/duckling/behaviors/PartialContentTest.java
@@ -1,0 +1,136 @@
+package duckling.behaviors;
+
+import duckling.requests.Request;
+import duckling.responses.CommonHeaders;
+import duckling.responses.Response;
+import duckling.responses.ResponseCodes;
+import duckling.support.SpyOutputStream;
+import org.junit.Test;
+
+import java.io.InputStream;
+import java.util.ArrayList;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class PartialContentTest {
+    @Test
+    public void returnsBasicResponseWithoutRangeHeaders() {
+        Response response = Response.wrap(new Request());
+        Behavior behavior = new PartialContent();
+
+        assertThat(behavior.apply(new Request()), is(response));
+    }
+
+    @Test
+    public void returnsPartialContentHeader() {
+        Request request = new Request();
+        Behavior behavior = new PartialContent();
+
+        request.add("GET / HTTP/1.1");
+        request.add("Range: byte=");
+
+        ArrayList<String> expectation =
+            Response
+                .wrap(new Request())
+                .withResponseCode(ResponseCodes.PARTIAL_CONTENT)
+                .getResponseHeaders();
+
+        assertThat(
+            behavior.apply(request).compose().getResponseHeaders(),
+            is(expectation)
+        );
+    }
+
+    @Test
+    public void abortsPartialContentAttemptWithMalformedRange() throws Exception {
+        Request request = new Request();
+        Behavior behavior = new PartialContent();
+
+        request.add("GET / HTTP/1.1");
+        request.add("Range: byte=2");
+
+        Response response =
+            Response
+                .wrap(request)
+                .withBody("Hello!")
+                .bind(behavior);
+
+        int input;
+        SpyOutputStream outputStream = new SpyOutputStream();
+        InputStream inputStream = response.compose().getBody();
+
+        while ((input = inputStream.read()) != -1) outputStream.write(input);
+
+        assertThat(outputStream.getWrittenOutput(), is("Hello!"));
+    }
+
+    @Test
+    public void returnsRemainderWhenGivenStartOnly() throws Exception {
+        Request request = new Request();
+        Behavior behavior = new PartialContent();
+
+        request.add("GET / HTTP/1.1");
+        request.add("Range: byte=2-");
+
+        Response response =
+            Response
+                .wrap(request)
+                .withBody("Hello!")
+                .bind(behavior);
+
+        int input;
+        SpyOutputStream outputStream = new SpyOutputStream();
+        InputStream inputStream = response.compose().getBody();
+
+        while ((input = inputStream.read()) != -1) outputStream.write(input);
+
+        assertThat(outputStream.getWrittenOutput(), is("llo!"));
+    }
+
+    @Test
+    public void returnsSliceWhenGivenBothParameters() throws Exception {
+        Request request = new Request();
+        Behavior behavior = new PartialContent();
+
+        request.add("GET / HTTP/1.1");
+        request.add("Range: byte=2-4");
+
+        Response response =
+            Response
+                .wrap(request)
+                .withBody("Hello!")
+                .bind(behavior);
+
+        int input;
+        SpyOutputStream outputStream = new SpyOutputStream();
+        InputStream inputStream = response.compose().getBody();
+
+        while ((input = inputStream.read()) != -1) outputStream.write(input);
+
+        assertThat(outputStream.getWrittenOutput(), is("llo"));
+    }
+    @Test
+    public void returnsTailEndWhenOnlyGivenSecondValue() throws Exception {
+        Request request = new Request();
+        Behavior behavior = new PartialContent();
+
+        request.add("GET / HTTP/1.1");
+        request.add("Range: byte=-2");
+
+        Response response =
+            Response
+                .wrap(request)
+                .withBody("Hello!")
+                .bind(behavior);
+
+        int input;
+        SpyOutputStream outputStream = new SpyOutputStream();
+        InputStream inputStream = response.compose().getBody();
+
+        while ((input = inputStream.read()) != -1) outputStream.write(input);
+
+        assertThat(outputStream.getWrittenOutput(), is("o!"));
+    }
+
+}

--- a/src/test/java/duckling/responses/MergeResponseTest.java
+++ b/src/test/java/duckling/responses/MergeResponseTest.java
@@ -6,6 +6,7 @@ import duckling.requests.Request;
 import org.junit.Test;
 
 import java.util.HashMap;
+import java.util.function.Function;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -73,6 +74,22 @@ public class MergeResponseTest {
 
         assertThat(
             merge.apply(other).behaviors.size(),
+            is(2)
+        );
+    }
+
+    @Test
+    public void combinesResponseBodyFilters() {
+        Response original = Response.wrap(new Request());
+        Response other = Response.wrap(new Request());
+
+        original.withResponseBodyFilter(Response::wrap);
+        other.withResponseBodyFilter(Response::wrap);
+
+        MergeResponse merge = new MergeResponse(original);
+
+        assertThat(
+            merge.apply(other).responseBodyFilters.size(),
             is(2)
         );
     }

--- a/src/test/java/duckling/responses/ResponseBodyTest.java
+++ b/src/test/java/duckling/responses/ResponseBodyTest.java
@@ -27,7 +27,9 @@ public class ResponseBodyTest {
 
     @Test
     public void isStreamIsTrueIfHandedStream() throws Exception {
-        assertThat(new ResponseBody(null, new ByteArrayInputStream("".getBytes())).isStream(), is(true));
+        InputStream stream = new ByteArrayInputStream("123".getBytes());
+
+        assertThat(new ResponseBody(null, stream).isStream(), is(true));
     }
 
     @Test
@@ -71,7 +73,7 @@ public class ResponseBodyTest {
 
     @Test
     public void requestingBytesWithStartReturnsClippedBytes() throws Exception {
-        assertThat(new ResponseBody("Hey").getBytes(1), is("ey".getBytes()));
+        assertThat(new ResponseBody("Heyo").getBytes(1), is("eyo".getBytes()));
     }
 
     @Test
@@ -84,6 +86,17 @@ public class ResponseBodyTest {
         byte[] content = "Hello".getBytes();
         InputStream stream = new ByteArrayInputStream(content);
         ResponseBody responseBody = new ResponseBody(null, stream);
+
+        assertThat(responseBody.getBytes(), is(content));
+    }
+
+    @Test
+    public void requestingBytesMultipleTimes() throws Exception {
+        byte[] content = "Hello".getBytes();
+        InputStream stream = new ByteArrayInputStream(content);
+        ResponseBody responseBody = new ResponseBody(null, stream);
+
+        responseBody.getBytes();
 
         assertThat(responseBody.getBytes(), is(content));
     }

--- a/src/test/java/duckling/responses/ResponseTest.java
+++ b/src/test/java/duckling/responses/ResponseTest.java
@@ -130,6 +130,27 @@ public class ResponseTest {
     }
 
     @Test
+    public void acceptsResponseBodyFilters() {
+        Response response =
+            Response
+                .wrap(new Request())
+                .withResponseBodyFilter(Response::wrap);
+
+        assertThat(response.responseBodyFilters.size(), is(1));
+    }
+
+    @Test
+    public void preservesResponseBodyFiltersWhenChained() {
+        Response response =
+            Response
+                .wrap(new Request())
+                .withResponseBodyFilter(Response::wrap)
+                .withBody("Hello!");
+
+        assertThat(response.responseBodyFilters.size(), is(1));
+    }
+
+    @Test
     public void canBuildHeaders() {
         HashMap<CommonHeaders, String> expectation = new HashMap<>();
         Response response =


### PR DESCRIPTION
This commit introduces a new concept, which is the idea that we can
filter a response body before outputting it.  This concept works a
little bit like a behavior, but right now we're gatekeeping it behind
behaviors for the sake of consistency.

An overview of the sibling concepts which made it into this update:

* Responses and ResponseBodies now support streams.
* Responses can accept and track response body filters.
* Merging responses combines response body filters.
* FileContents responder now fully relies on behaviors.

From a bird's eye view, this and the coming options request change means
that we might be able to deprecate or meaningfully change responders.