### PR TITLE
Recognize options requests.

### DIFF
--- a/src/main/java/duckling/Configuration.java
+++ b/src/main/java/duckling/Configuration.java
@@ -12,6 +12,10 @@ public class Configuration {
     private static final int DEFAULT_PORT = 5000;
     private static final String DEFAULT_ROOT = ".";
     public static final RouteDefinitions DEFAULT_ROUTES = new RouteDefinitions(
+        Routes.put("/method_options").with(new StaticBody("")),
+        Routes.post("/method_options").with(new StaticBody("")),
+        Routes.get("/method_options").with(new StaticBody("")),
+        Routes.get("/method_options2").with(new StaticBody("")),
         Routes.put("/form").with(new StoreMemoryWithPath()),
         Routes.post("/form").with(new StoreMemoryWithPath()),
         Routes.get("/form").with(new RetrieveMemoryWithPath()),

--- a/src/main/java/duckling/behaviors/HasOptions.java
+++ b/src/main/java/duckling/behaviors/HasOptions.java
@@ -4,11 +4,18 @@ import duckling.requests.Request;
 import duckling.responses.CommonHeaders;
 import duckling.responses.Response;
 
+import java.util.ArrayList;
+import java.util.stream.Collectors;
+
 public class HasOptions implements Behavior {
     private String allowedMethodsString;
 
     public HasOptions(String allowedMethodsString) {
         this.allowedMethodsString = allowedMethodsString;
+    }
+
+    public HasOptions(ArrayList<String> allowedMethods) {
+        this(allowedMethods.stream().collect(Collectors.joining(",")));
     }
 
     @Override

--- a/src/main/java/duckling/behaviors/MaybeRouteHeaders.java
+++ b/src/main/java/duckling/behaviors/MaybeRouteHeaders.java
@@ -1,12 +1,14 @@
 package duckling.behaviors;
 
 import duckling.requests.Request;
+import duckling.responses.CommonHeaders;
 import duckling.responses.Response;
 import duckling.responses.ResponseCodes;
 import duckling.routing.Route;
 import duckling.routing.RouteDefinitions;
 
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 public class MaybeRouteHeaders implements Behavior {
     private RouteDefinitions routes;
@@ -14,13 +16,27 @@ public class MaybeRouteHeaders implements Behavior {
     public MaybeRouteHeaders(RouteDefinitions routes) {
         this.routes = routes;
     }
+
     @Override
     public Response apply(Request request) {
+        if (request.isOptions() && routes.hasPath(request.getPath())) {
+            return Response
+                .wrap(request)
+                .withResponseCode(ResponseCodes.OK)
+                .withHeader(
+                    CommonHeaders.ALLOW,
+                    routes
+                        .allMethodsForRoute(request.getPath())
+                        .stream()
+                        .collect(Collectors.joining(","))
+                );
+        }
+
         Optional<Route> maybeRoute = routes.getMatch(request);
 
         return maybeRoute.
             map(
-                (route) ->
+                route ->
                     Response
                         .wrap(request)
                         .withBehaviors(route.getBehaviors())

--- a/src/main/java/duckling/responders/RoutedContents.java
+++ b/src/main/java/duckling/responders/RoutedContents.java
@@ -14,13 +14,16 @@ public class RoutedContents extends Responder {
 
         this.routes = config.routes;
 
-        response.bind(new HasOptions(allowedMethodsString()));
+        response.bind(new HasOptions(routes.allMethodsForRoute(request.getPath())));
         response.bind(new MaybeRoute(config.routes));
     }
 
     @Override
     public boolean matches() {
-        return routes.hasRoute(request);
+        boolean validOptionsRequest = (request.isOptions() && routes.hasPath(request.getPath()));
+        boolean validRouteRequest = routes.hasRoute(request);
+
+        return validOptionsRequest || validRouteRequest;
     }
 
 }

--- a/src/main/java/duckling/routing/Route.java
+++ b/src/main/java/duckling/routing/Route.java
@@ -45,6 +45,10 @@ public class Route {
         return new Route(method, routeName, pages);
     }
 
+    public String getMethod() {
+        return this.method;
+    }
+
     public boolean hasMethod(String method) {
         return this.method.equals(method);
     }

--- a/src/main/java/duckling/routing/RouteDefinitions.java
+++ b/src/main/java/duckling/routing/RouteDefinitions.java
@@ -39,6 +39,32 @@ public class RouteDefinitions {
 
     @Override
     public String toString() {
-        return contents.stream().map(Route::toString).collect(Collectors.joining(Server.CRLF));
+        return contents
+            .stream()
+            .map(Route::toString)
+            .collect(Collectors.joining(Server.CRLF));
+    }
+
+    public ArrayList<String> allMethodsForRoute(String route) {
+        ArrayList<String> methods = new ArrayList<>();
+
+        methods.add("HEAD");
+        methods.add("OPTIONS");
+
+        contents
+            .stream()
+            .filter(candidate -> candidate.hasRoute(route))
+            .forEach(candidate -> methods.add(candidate.getMethod()));
+
+        methods.sort(Comparator.comparing(String::toString));
+
+        return methods;
+    }
+
+    public boolean hasPath(String path) {
+        return contents
+            .stream()
+            .filter(candidate -> candidate.hasRoute(path))
+            .count() > 0;
     }
 }

--- a/src/test/java/duckling/behaviors/MaybeRouteHeadersTest.java
+++ b/src/test/java/duckling/behaviors/MaybeRouteHeadersTest.java
@@ -1,6 +1,7 @@
 package duckling.behaviors;
 
 import duckling.requests.Request;
+import duckling.responses.CommonHeaders;
 import duckling.responses.Response;
 import duckling.responses.ResponseCodes;
 import duckling.routing.RouteDefinitions;
@@ -11,6 +12,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 public class MaybeRouteHeadersTest {
+
     @Test
     public void suppliesDefinedContentIfGivenMatch() throws Exception {
         RouteDefinitions definitions = new RouteDefinitions(
@@ -29,6 +31,29 @@ public class MaybeRouteHeadersTest {
                     .wrap(new Request())
                     .withResponseCode(ResponseCodes.TEAPOT)
                     .withContentType("text/html")
+                    .getResponseHeaders()
+            )
+        );
+    }
+
+    @Test
+    public void suppliesDefinedContentIfGivenValidOptionsRequest() throws Exception {
+        RouteDefinitions definitions = new RouteDefinitions(
+            Routes.get("/hello").with(new RespondWith(ResponseCodes.TEAPOT), new StaticBody("Hey"))
+        );
+
+        Behavior behavior = new MaybeRouteHeaders(definitions);
+
+        Request request = new Request();
+        request.add("OPTIONS /hello HTTP/1.1");
+
+        assertThat(
+            behavior.apply(request).compose().getResponseHeaders(),
+            is(
+                Response
+                    .wrap(new Request())
+                    .withResponseCode(ResponseCodes.OK)
+                    .withHeader(CommonHeaders.ALLOW, "GET,HEAD,OPTIONS")
                     .getResponseHeaders()
             )
         );

--- a/src/test/java/duckling/responders/RoutedContentsTest.java
+++ b/src/test/java/duckling/responders/RoutedContentsTest.java
@@ -17,6 +17,7 @@ import org.junit.Test;
 
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.stream.Collectors;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -106,16 +107,21 @@ public class RoutedContentsTest {
 
     @Test
     public void presentsGetHeadOptionsAsOptions() throws Exception {
+        String methods = config
+            .routes
+            .allMethodsForRoute("/coffee")
+            .stream()
+            .collect(Collectors.joining(","));
+
         request = new Request();
         request.add("OPTIONS /coffee HTTP/1.1");
 
         responder = new RoutedContents(request, config);
-
         ArrayList<String> headers =
             Response
                 .wrap(request)
                 .withResponseCode(ResponseCodes.NOT_FOUND)
-                .withHeader(CommonHeaders.ALLOW, responder.allowedMethodsString())
+                .withHeader(CommonHeaders.ALLOW, methods)
                 .getResponseHeaders();
 
         assertThat(responder.headers(), is(headers));

--- a/src/test/java/duckling/routing/RouteDefinitionsTest.java
+++ b/src/test/java/duckling/routing/RouteDefinitionsTest.java
@@ -2,6 +2,10 @@ package duckling.routing;
 
 import org.junit.Test;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
@@ -9,9 +13,40 @@ public class RouteDefinitionsTest {
 
     @Test
     public void matchesDefinitionObjectsWithSameContents() {
-        RouteDefinitions definitions = new RouteDefinitions(Routes.get("coffee"));
-        RouteDefinitions other = new RouteDefinitions(Routes.get("coffee"));
+        RouteDefinitions definitions = new RouteDefinitions(Routes.get("/coffee"));
+        RouteDefinitions other = new RouteDefinitions(Routes.get("/coffee"));
         assertThat(definitions, is(other));
+    }
+
+    @Test
+    public void hasPathIsTrueWhenPathDefined() {
+        RouteDefinitions definitions = new RouteDefinitions(Routes.get("/coffee"));
+        assertThat(definitions.hasPath("/coffee"), is(true));
+    }
+
+    @Test
+    public void hasPathIsFalseWhenPathNotDefined() {
+        RouteDefinitions definitions = new RouteDefinitions(Routes.get("/coffee"));
+        assertThat(definitions.hasPath("/tea"), is(false));
+    }
+
+    @Test
+    public void allMethodsForRoute() {
+        RouteDefinitions definitions = new RouteDefinitions(
+            Routes.post("/coffee"),
+            Routes.get("/coffee")
+        );
+
+        ArrayList<String> expectation = new ArrayList<>(
+            Arrays.asList("POST", "GET", "HEAD", "OPTIONS")
+        );
+
+        expectation.sort(Comparator.comparing(String::toString));
+
+        assertThat(
+            definitions.allMethodsForRoute("/coffee"),
+            is(expectation)
+        );
     }
 
 }


### PR DESCRIPTION
This commit formalizes dynamic options requests.  That is to say, if we
have an OPTIONS request coming, file contents, folder contents, and not
found paths responded correctly - but defined routes only fed back a
preprogrammed string.  Now, however, duckling will actually look into
its route definitions for all available methods for a route, and provide
those to the HasOptions behavior.