### PR TITLE
Add PATCH and eTag support.

### DIFF
--- a/src/main/java/duckling/behaviors/PatchTextContent.java
+++ b/src/main/java/duckling/behaviors/PatchTextContent.java
@@ -1,0 +1,27 @@
+package duckling.behaviors;
+
+import duckling.requests.Request;
+import duckling.responses.Response;
+import duckling.responses.ResponseCodes;
+
+import java.util.stream.Collectors;
+
+public class PatchTextContent implements Behavior {
+
+    @Override
+    public Response apply(Request request) {
+        Response response = Response.wrap(request);
+        String ifMatch = request.headers.get("If-Match");
+
+        if (!request.fileExists() || ifMatch.isEmpty()) return response;
+
+        String update = request.getBody().stream().collect(Collectors.joining());
+
+        if (request.maybeWrite(ifMatch, update)) {
+            return response.withResponseCode(ResponseCodes.NO_CONTENT).withBody("");
+        }
+
+        return response;
+    }
+
+}

--- a/src/main/java/duckling/responders/FileContents.java
+++ b/src/main/java/duckling/responders/FileContents.java
@@ -18,6 +18,7 @@ public class FileContents extends Responder {
         response.bind(new GuessContentType());
         response.bind(new DisplayFile());
         response.bind(new PartialContent());
+        response.bind(new PatchTextContent());
     }
 
     @Override

--- a/src/main/java/duckling/responders/Responder.java
+++ b/src/main/java/duckling/responders/Responder.java
@@ -1,6 +1,5 @@
 package duckling.responders;
 
-import duckling.Server;
 import duckling.requests.Request;
 import duckling.responses.Response;
 
@@ -11,7 +10,9 @@ import java.util.stream.Collectors;
 
 public abstract class Responder {
     Response response;
+    Response composedResponse;
     Request request;
+
     ArrayList<String> allowedMethods = new ArrayList<>(
         Arrays.asList("GET", "HEAD", "OPTIONS")
     );
@@ -21,12 +22,20 @@ public abstract class Responder {
         this.request = request;
     }
 
+    private Response getComposedResponse() {
+        if (composedResponse != null) return composedResponse;
+
+        this.composedResponse = response.compose();
+
+        return composedResponse;
+    }
+
     public InputStream body() {
-        return response.compose().getBody();
+        return getComposedResponse().getBody();
     }
 
     public ArrayList<String> headers() {
-        return response.compose().getResponseHeaders();
+        return getComposedResponse().getResponseHeaders();
     }
 
     public String allowedMethodsString() {

--- a/src/main/java/duckling/responders/RoutedContents.java
+++ b/src/main/java/duckling/responders/RoutedContents.java
@@ -16,6 +16,8 @@ public class RoutedContents extends Responder {
 
         response.bind(new HasOptions(routes.allMethodsForRoute(request.getPath())));
         response.bind(new MaybeRoute(config.routes));
+
+        this.response = response.compose();
     }
 
     @Override

--- a/src/main/java/duckling/responses/Response.java
+++ b/src/main/java/duckling/responses/Response.java
@@ -55,7 +55,7 @@ public class Response {
     }
 
     public HashMap<CommonHeaders, String> getHeaders() {
-        return compose().headers;
+        return headers;
     }
 
     public ArrayList<String> getHeaderList() {
@@ -78,7 +78,7 @@ public class Response {
     public ArrayList<String> getResponseHeaders() {
         ArrayList<String> lines = new ArrayList<>();
 
-        lines.add("HTTP/1.0 " + compose().getResponseCodeWithDefault() + Server.CRLF);
+        lines.add("HTTP/1.0 " + getResponseCodeWithDefault() + Server.CRLF);
         lines.addAll(getHeaderList());
         lines.add(Server.CRLF);
 

--- a/src/main/java/duckling/responses/ResponseCodes.java
+++ b/src/main/java/duckling/responses/ResponseCodes.java
@@ -2,6 +2,7 @@ package duckling.responses;
 
 public enum ResponseCodes {
     OK                    (200, "OK"),
+    NO_CONTENT            (204, "NO CONTENT"),
     PARTIAL_CONTENT       (206, "PARTIAL CONTENT"),
     FOUND                 (302, "FOUND"),
     BAD_REQUEST           (400, "BAD REQUEST"),

--- a/src/test/java/duckling/behaviors/PatchTextContentTest.java
+++ b/src/test/java/duckling/behaviors/PatchTextContentTest.java
@@ -1,0 +1,64 @@
+package duckling.behaviors;
+
+import duckling.requests.Request;
+import duckling.responses.Response;
+import duckling.responses.ResponseCodes;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class PatchTextContentTest {
+    @Test
+    public void returnsEmptyResponseUnlessFileExists() throws Exception {
+        Behavior behavior = new PatchTextContent();
+        Request request = new Request() {
+            @Override
+            public boolean fileExists() { return false; }
+        };
+
+        assertThat(behavior.apply(request), is(Response.wrap(request)));
+    }
+
+    @Test
+    public void returnsEmptyResponseWhenIfMatchIsAbsent() throws Exception {
+        Behavior behavior = new PatchTextContent();
+        Request request = new Request();
+
+        assertThat(behavior.apply(request), is(Response.wrap(request)));
+    }
+
+    @Test
+    public void returnEmptyResponseWhenMaybeWriteIsFalse() throws Exception {
+        Behavior behavior = new PatchTextContent();
+        Request request = new Request() {
+            @Override
+            public boolean maybeWrite(String string, String content) { return false; }
+        };
+
+        assertThat(behavior.apply(request), is(Response.wrap(request)));
+    }
+
+    @Test
+    public void returnsNoContentOtherwise() throws Exception {
+        Behavior behavior = new PatchTextContent();
+        Request request = new Request() {
+            @Override
+            public boolean fileExists() { return true; }
+
+            @Override
+            public boolean maybeWrite(String string, String content) { return true; }
+        };
+
+        request.add("GET / HTTP/1.1");
+        request.add("If-Match: abcdefgH");
+
+        Response expectation =
+            Response
+                .wrap(request)
+                .withResponseCode(ResponseCodes.NO_CONTENT);
+
+        assertThat(behavior.apply(request), is(expectation));
+    }
+
+}

--- a/src/test/java/duckling/requests/RequestTest.java
+++ b/src/test/java/duckling/requests/RequestTest.java
@@ -6,10 +6,13 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 
+import duckling.Configuration;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.io.File;
+import java.security.MessageDigest;
+import static sun.security.pkcs11.wrapper.Functions.toHexString;
 
 public class RequestTest {
     private Request request;
@@ -107,6 +110,35 @@ public class RequestTest {
     public void isOptionsReturnsTrueIfMethodIsOptions() throws Exception {
         request.add("OPTIONS / HTTP/1.1");
         assertThat(request.isOptions(), is(true));
+    }
+
+    @Test
+    public void getFilePathReturnsAbsolutePath() throws Exception {
+        String path = "/some/path/string";
+        Configuration config = new Configuration(5000, path);
+        Request request = new Request(config);
+        request.add("OPTIONS /file.txt HTTP/1.1");
+        assertThat(request.getFilePath(), is(path + "/file.txt"));
+    }
+
+    @Test
+    public void fileHexDigestReturnsHexStringOfFile() throws Exception {
+        MessageDigest digest = MessageDigest.getInstance("SHA-1");
+        byte[] contents = "default contents".getBytes();
+
+        digest.update(contents);
+
+        Request request = new Request( ) {
+            @Override
+            public byte[] readFile() {
+                return contents;
+            }
+        };
+
+        assertThat(
+            request.getFileHexString(),
+            is(toHexString(digest.digest()))
+        );
     }
 
 }

--- a/src/test/java/duckling/responders/RoutedContentsTest.java
+++ b/src/test/java/duckling/responders/RoutedContentsTest.java
@@ -131,11 +131,7 @@ public class RoutedContentsTest {
     public void suppliesTheRouteDefinedBody() throws Exception {
         SpyOutputStream outputStream = new SpyOutputStream();
         InputStream inputStream = responder.body();
-        String expectation =
-            "<html>" +
-                "<head><title>/tea</title></head>" +
-                "<body>Tea indeed</body>" +
-                "</html>";
+        String expectation = "Tea indeed";
 
         int input;
 

--- a/src/test/java/duckling/responses/ResponseTest.java
+++ b/src/test/java/duckling/responses/ResponseTest.java
@@ -189,7 +189,7 @@ public class ResponseTest {
         expectation.put(CommonHeaders.LOCATION, "/");
         expectation.put(CommonHeaders.CONTENT_TYPE, "application/json");
 
-        assertThat(response.getHeaders(), is(expectation));
+        assertThat(response.compose().getHeaders(), is(expectation));
     }
 
     @Test


### PR DESCRIPTION
eTag / partial content support was the final feature requirement for
Duckling, and so this commit brings us up to standards.  But, is it
really over?  Maybe not.  There's still plenty to do:

* A simpler object system for Requests would be nice.
* Why are Response objects so dang huge?
* Do we really need Responders at all?
* Are we following good package principles overall? (Hint: Probably not)
* There's a big opportunity for better test coverage.
* What can we do about all the try/catch blocks?