### PR TITLE
Add Makefile and expanded build instructions.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+GRADLE=`./get_gradle.sh`
+
+all: report clean build
+
+build:
+	@$(GRADLE) build
+
+clean:
+	@$(GRADLE) clean
+
+report:
+	@echo "Using: $(GRADLE)"
+
+start: all
+	java -jar duckling.jar

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/esmevane/duckling.svg?branch=master)](https://travis-ci.org/esmevane/duckling)
+[![Build Status][build-status-img]][build-status-link]
 
 # Duckling
 
@@ -6,9 +6,9 @@ A petite Java http server, with the major goals of being enjoyable to read and w
 
 ## Installation
 
-Duckling is run with `duckling.jar` releases, found on our [releases page](https://github.com/esmevane/duckling/releases) - you can get the latest `duckling.jar` there.  Or, if you like, you can get the latest `duckling.jar` [by clicking right here](https://github.com/esmevane/duckling/releases/download/v0.0.2/duckling.jar).
+Duckling is run with `duckling.jar` releases, found on our [releases page][releases] - you can get the latest `duckling.jar` there.  Or, if you like, you can get the latest `duckling.jar` [by clicking right here][latest-jar].
 
-If you like your command line, here's a good one-liner (you might need to grab `wget` first):
+If you like your command line, and you don't want the whole quacking project, here's a good one-liner (you might need to grab `wget` first):
 
 ```bash
 wget https://github.com/esmevane/duckling/releases/download/v0.0.2/duckling.jar
@@ -21,19 +21,31 @@ If building the current master (or a given release) directly is more your speed,
 ```bash
 git clone git@github.com:esmevane/duckling.git
 cd duckling
-./gradlew test && ./gradlew jar
+make
 ```
 
-That snippet will grab this repository, install it in your `$(pwd)/duckling`, hop into that directory, and then use the `./gradlew` build scripts to get a jar together.  It will deposit the jar in the root of the duckling directory, under `duckling.jar`.
+That snippet will grab this repository, install it in your `$(pwd)/duckling`, hop into that directory, and then use either `which gradle` or the `./gradlew` build scripts to get a build together.
 
-Enjoy!
+The final result of the `make` process is a jar in the root of the duckling directory, named `duckling.jar`.
+
+### Do you need to clean and restart?
+
+If so, just run `make` again.  It will clean up the gradle build artifacts, rerun the tests and then rebuild.
 
 ## Usage
 
-Once you've either downloaded or created your `duckling.jar`, you can run it with Java:
+Once you've run `make` once, you've created your `duckling.jar`.  Now, you can run it with Java:
 
 ```bash
 java -jar duckling.jar
+```
+
+Alternately, if you want to keep using `make`, that's fine, too.  Maybe even more than fine, it might be _better_.  That's because running `make` will perform a full clean, test, and rebuild before it does anything.
+
+The command is easy:
+
+```bash
+make start
 ```
 
 ### Configuring the Duckling Jar
@@ -68,7 +80,18 @@ Duckling has been built with a preconfigured set of routes, which are there pure
 | GET | / | 200 OK | The public directory |
 | GET | /coffee | 418 TEAPOT | A quirky teapot code |
 | GET | /tea | 200 OK | You probably meant to go here, not to /coffee |
-| POST | /form | 200 OK | Just a happy little route, look at this route |
-| PUT | /form | 200 OK | This happy little route accepts PUT requests, too |
+| GET, POST, PUT, DELETE | /form | 200 OK | Just a happy little route, look at this route |
 | GET | /redirect | 302 FOUND | Sends you to the root path |
 | GET | /parameters | 200 OK | Echoes any query parameters you give it |
+| GET | /logs | 200 OK | Check out those logs.  Wait, do you have the password? |
+| GET | /cookie | 200 OK | Give us a `type` query param with your favorite flavor |
+| GET | /eat_cookie | 200 OK | You did tell us know what flavor you like, right? |
+| GET | /method_options2 | 200 OK | Just a nice route |
+| GET, PUT, POST | /method_options | 200 OK | This one, too! |
+
+You can send any of these routes `HEAD` or `OPTIONS` requests as well!
+
+[build-status-img]: https://travis-ci.org/esmevane/duckling.svg?branch=master
+[build-status-link]: https://travis-ci.org/esmevane/duckling
+[releases]: https://github.com/esmevane/duckling/releases
+[latest-jar]: https://github.com/esmevane/duckling/releases/download/v0.0.2/duckling.jar

--- a/get_gradle.sh
+++ b/get_gradle.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+GRADLE=`which gradle`
+WRAPPER="./gradlew"
+
+[ -e "$GRADLE" ] && echo "$GRADLE" || echo "$WRAPPER"


### PR DESCRIPTION
In order to improve the quality of life of anyone who might take a
gander at duckling, we're going to add a Makefile with the most common
basic operations you might want to use gradle for.  The Makefile will
gracefully downgrade to ./gradlew if there isn't a gradle available on
the host machine.