### PR TITLE
Extensive optimization pass.

### DIFF
--- a/src/main/java/duckling/Server.java
+++ b/src/main/java/duckling/Server.java
@@ -19,7 +19,7 @@ public class Server {
         this(
             config,
             new ServerSocket(),
-            Executors.newCachedThreadPool()
+            Executors.newFixedThreadPool(10)
         );
     }
 

--- a/src/main/java/duckling/behaviors/DisplayFile.java
+++ b/src/main/java/duckling/behaviors/DisplayFile.java
@@ -3,24 +3,22 @@ package duckling.behaviors;
 import duckling.requests.Request;
 import duckling.responses.Response;
 
-import java.io.BufferedInputStream;
-import java.io.ByteArrayInputStream;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
+import java.io.*;
 
 public class DisplayFile implements Behavior {
     @Override
     public Response apply(Request request) {
-        Response response = Response.wrap(request);
+        return Response
+            .wrap(request)
+            .withStreamBody(new BufferedInputStream(getStream(request)));
+    }
 
+    private InputStream getStream(Request request) {
         try {
-            return response.withStreamBody(
-                new BufferedInputStream(
-                    new FileInputStream(request.getFile().getAbsoluteFile())
-                )
-            );
+            return new FileInputStream(request.getFilePath());
         } catch (FileNotFoundException exception) {
-            return response.withStreamBody(new ByteArrayInputStream("".getBytes()));
+            return new ByteArrayInputStream("".getBytes());
         }
+
     }
 }

--- a/src/main/java/duckling/behaviors/MaybeBehavior.java
+++ b/src/main/java/duckling/behaviors/MaybeBehavior.java
@@ -1,0 +1,24 @@
+package duckling.behaviors;
+
+import duckling.requests.Request;
+import duckling.responses.Response;
+
+import java.util.function.Predicate;
+
+public class MaybeBehavior implements Behavior {
+    Predicate<Request> condition;
+    Behavior behavior;
+
+    public MaybeBehavior(Predicate<Request> condition, Behavior behavior) {
+        this.condition = condition;
+        this.behavior = behavior;
+    }
+
+    @Override
+    public Response apply(Request request) {
+        if (condition.test(request)) return behavior.apply(request);
+
+        return Response.wrap(request);
+    }
+
+}

--- a/src/main/java/duckling/behaviors/PartialContent.java
+++ b/src/main/java/duckling/behaviors/PartialContent.java
@@ -5,6 +5,7 @@ import duckling.responses.ResponseBodyFilter;
 import duckling.responses.Response;
 import duckling.responses.ResponseCodes;
 
+import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.util.ArrayList;
@@ -21,20 +22,18 @@ public class PartialContent implements Behavior {
 
         ResponseBodyFilter responseBodyFilter = (givenResponse) -> {
             try {
-                byte[] content;
                 Range range = new Range(rawRange);
+                byte[] content = givenResponse.responseBody.getBytes();
 
                 if (range.noDefinedEnd()) {
-                    content = givenResponse.responseBody.getBytes(range.from());
+                    content = Arrays.copyOfRange(content, range.from(), content.length);
                 } else if (range.noDefinedStart()) {
-                    content = givenResponse.responseBody.getBytes(
-                        givenResponse.responseBody.getBytes().length - range.to()
-                    );
+                    content = Arrays.copyOfRange(content, content.length - range.to(), content.length);
                 } else {
-                    content = givenResponse.responseBody.getBytes(range.from(), range.to());
+                    content = Arrays.copyOfRange(content, range.from(), range.to() + 1);
                 }
 
-                InputStream stream = new ByteArrayInputStream(content);
+                InputStream stream = new BufferedInputStream(new ByteArrayInputStream(content));
 
                 return givenResponse.withStreamBody(stream);
             } catch (IndexOutOfBoundsException exception) {

--- a/src/main/java/duckling/responders/FileContents.java
+++ b/src/main/java/duckling/responders/FileContents.java
@@ -17,8 +17,20 @@ public class FileContents extends Responder {
         response.bind(new RestrictToMethods(allowedMethods));
         response.bind(new GuessContentType());
         response.bind(new DisplayFile());
-        response.bind(new PartialContent());
-        response.bind(new PatchTextContent());
+
+        response.bind(
+            new MaybeBehavior(
+                (givenRequest) -> !givenRequest.headers.get("Range").isEmpty(),
+                new PartialContent()
+            )
+        );
+
+        response.bind(
+            new MaybeBehavior(
+                (givenRequest) -> !givenRequest.headers.get("If-Match").isEmpty(),
+                new PatchTextContent()
+            )
+        );
     }
 
     @Override

--- a/src/main/java/duckling/responses/MergeResponse.java
+++ b/src/main/java/duckling/responses/MergeResponse.java
@@ -14,23 +14,19 @@ class MergeResponse {
     public Response apply(Response other) {
         ResponseBody responseBody = response.responseBody.merge(other.responseBody);
 
-        ResponseCodes responseCode =
-            other.responseCode == null ?
-                response.responseCode :
-                other.responseCode;
-
         HashMap<CommonHeaders, String> headers = new HashMap<>(response.headers);
 
         other.headers.forEach(headers::put);
 
-        return Response
-            .wrap(other.request)
-            .withResponseBody(responseBody)
-            .withBehaviors(response.behaviors)
-            .withBehaviors(other.behaviors)
-            .withResponseBodyFilters(response.responseBodyFilters)
-            .withResponseBodyFilters(other.responseBodyFilters)
-            .withHeaders(headers)
-            .withResponseCode(responseCode);
+        return new ResponseBuilder()
+            .setRequest(other.request)
+            .setResponseBody(responseBody)
+            .setResponseCode(other.responseCode == null ? response.responseCode : other.responseCode)
+            .addBehaviors(response.behaviors)
+            .addBehaviors(other.behaviors)
+            .addResponseBodyFilters(response.responseBodyFilters)
+            .addResponseBodyFilters(other.responseBodyFilters)
+            .setHeaders(headers)
+            .toResponse();
     }
 }

--- a/src/main/java/duckling/responses/ResponseBuilder.java
+++ b/src/main/java/duckling/responses/ResponseBuilder.java
@@ -1,0 +1,115 @@
+package duckling.responses;
+
+import duckling.behaviors.Behavior;
+import duckling.requests.Request;
+
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.HashMap;
+
+public class ResponseBuilder {
+    ResponseCodes responseCode;
+    ResponseBody responseBody = new ResponseBody("");
+    Request request = new Request();
+    HashMap<CommonHeaders, String> headers = new HashMap<>();
+    ArrayList<Behavior> behaviors = new ArrayList<>();
+    ArrayList<ResponseBodyFilter> responseBodyFilters = new ArrayList<>();
+
+    public ResponseBuilder addBehaviors(ArrayList<Behavior> behaviors) {
+        behaviors.forEach(this.behaviors::add);
+
+        return this;
+    }
+
+    public ResponseBuilder addResponseBodyFilters(ArrayList<ResponseBodyFilter> responseBodyFilters) {
+        responseBodyFilters.forEach(this.responseBodyFilters::add);
+
+        return this;
+    }
+
+    public ResponseBuilder addBehavior(Behavior behavior) {
+        behaviors.add(behavior);
+
+        return this;
+    }
+
+    public ResponseBuilder addResponseBodyFilter(ResponseBodyFilter responseBodyFilter) {
+        responseBodyFilters.add(responseBodyFilter);
+
+        return this;
+    }
+
+    public ResponseBuilder setBody(String body) {
+        if (body == null) {
+            this.responseBody = new ResponseBody(null, true);
+        } else {
+            this.responseBody = new ResponseBody(body);
+        }
+
+        return this;
+    }
+
+    public ResponseBuilder setHeader(CommonHeaders key, String content) {
+        if (content == null) {
+            headers.remove(key);
+        } else {
+            headers.put(key, content);
+        }
+
+        return this;
+    }
+
+    public ResponseBuilder setHeaders(HashMap<CommonHeaders, String> headers) {
+        this.headers = headers;
+
+        return this;
+    }
+
+    public ResponseBuilder setResponseBody(ResponseBody responseBody) {
+        this.responseBody = responseBody;
+
+        return this;
+    }
+
+    public ResponseBuilder setResponseBodyFilters(ArrayList<ResponseBodyFilter> responseBodyFilters) {
+        this.responseBodyFilters = responseBodyFilters;
+
+        return this;
+    }
+
+    public ResponseBuilder setResponseCode(ResponseCodes responseCode) {
+        this.responseCode = responseCode;
+
+        return this;
+    }
+
+    public ResponseBuilder setRequest(Request request) {
+        this.request = request;
+
+        return this;
+    }
+
+    public ResponseBuilder setStreamBody(InputStream inputStream) {
+        this.responseBody = new ResponseBody("", inputStream);
+
+        return this;
+    }
+
+    public ResponseBuilder setBehaviors(ArrayList<Behavior> behaviors) {
+        this.behaviors = behaviors;
+
+        return this;
+    }
+
+    public Response toResponse() {
+        return new Response(
+            request,
+            behaviors,
+            responseBodyFilters,
+            headers,
+            responseCode,
+            responseBody
+        );
+    }
+
+}

--- a/src/test/java/duckling/ServerTest.java
+++ b/src/test/java/duckling/ServerTest.java
@@ -1,7 +1,5 @@
 package duckling;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.IsCollectionContaining.hasItem;
 import static org.junit.Assert.assertEquals;
 
 import duckling.support.SpyServerSocket;

--- a/src/test/java/duckling/behaviors/MaybeBehaviorTest.java
+++ b/src/test/java/duckling/behaviors/MaybeBehaviorTest.java
@@ -1,0 +1,32 @@
+package duckling.behaviors;
+
+import duckling.requests.Request;
+import duckling.responses.Response;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class MaybeBehaviorTest {
+    @Test
+    public void applyAddsGivenBehaviorWhenConditionIsTrue() throws Exception {
+        String body = "Yay!";
+        Behavior behavior = new MaybeBehavior(
+            (request) -> true,
+            (request) -> Response.wrap(request).withBody(body)
+        );
+
+        assertThat(behavior.apply(new Request()).getStringBody(), is(body));
+    }
+
+    @Test
+    public void applyDoesNotAddGivenBehaviorWhenConditionIsFalse() throws Exception {
+        String body = "Yay!";
+        Behavior behavior = new MaybeBehavior(
+            (request) -> false,
+            (request) -> Response.wrap(request).withBody(body)
+        );
+
+        assertThat(behavior.apply(new Request()).getStringBody(), is(""));
+    }
+}

--- a/src/test/java/duckling/behaviors/MaybeRouteBodyTest.java
+++ b/src/test/java/duckling/behaviors/MaybeRouteBodyTest.java
@@ -20,10 +20,7 @@ public class MaybeRouteBodyTest {
         Request request = new Request();
         request.add("GET /hello HTTP/1.1");
 
-        assertThat(
-            behavior.apply(request).compose().getStringBody(),
-            is("<html><head><title>/hello</title></head><body>Hey</body></html>")
-        );
+        assertThat(behavior.apply(request).compose().getStringBody(), is("Hey"));
     }
 
     @Test

--- a/src/test/java/duckling/behaviors/PartialContentTest.java
+++ b/src/test/java/duckling/behaviors/PartialContentTest.java
@@ -1,7 +1,6 @@
 package duckling.behaviors;
 
 import duckling.requests.Request;
-import duckling.responses.CommonHeaders;
 import duckling.responses.Response;
 import duckling.responses.ResponseCodes;
 import duckling.support.SpyOutputStream;
@@ -110,6 +109,7 @@ public class PartialContentTest {
 
         assertThat(outputStream.getWrittenOutput(), is("llo"));
     }
+
     @Test
     public void returnsTailEndWhenOnlyGivenSecondValue() throws Exception {
         Request request = new Request();

--- a/src/test/java/duckling/responses/MergeResponseTest.java
+++ b/src/test/java/duckling/responses/MergeResponseTest.java
@@ -6,7 +6,6 @@ import duckling.requests.Request;
 import org.junit.Test;
 
 import java.util.HashMap;
-import java.util.function.Function;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/src/test/java/duckling/responses/ResponseBodyTest.java
+++ b/src/test/java/duckling/responses/ResponseBodyTest.java
@@ -72,16 +72,6 @@ public class ResponseBodyTest {
     }
 
     @Test
-    public void requestingBytesWithStartReturnsClippedBytes() throws Exception {
-        assertThat(new ResponseBody("Heyo").getBytes(1), is("eyo".getBytes()));
-    }
-
-    @Test
-    public void requestingBytesWithStartAndEndReturnsClippedBytes() throws Exception {
-        assertThat(new ResponseBody("Heyo").getBytes(1, 2), is("ey".getBytes()));
-    }
-
-    @Test
     public void getBytesReturnsStreamBytesIfIsStream() throws Exception {
         byte[] content = "Hello".getBytes();
         InputStream stream = new ByteArrayInputStream(content);
@@ -96,7 +86,7 @@ public class ResponseBodyTest {
         InputStream stream = new ByteArrayInputStream(content);
         ResponseBody responseBody = new ResponseBody(null, stream);
 
-        responseBody.getBytes();
+        responseBody.getContent();
 
         assertThat(responseBody.getBytes(), is(content));
     }

--- a/src/test/java/duckling/responses/ResponseTest.java
+++ b/src/test/java/duckling/responses/ResponseTest.java
@@ -80,7 +80,10 @@ public class ResponseTest {
         request.add("GET /path HTTP/1.1");
 
         Response subject = Response.wrap(request);
-        Response expectation = Response.wrap(request);
+        Response expectation =
+            Response
+                .wrap(request)
+                .withResponseCode(ResponseCodes.NOT_FOUND);
 
         subject.bind(
             (givenRequest) ->
@@ -88,8 +91,6 @@ public class ResponseTest {
                     .wrap(givenRequest)
                     .withResponseCode(ResponseCodes.NOT_FOUND)
         );
-
-        expectation.setResponseCode(ResponseCodes.NOT_FOUND);
 
         assertThat(subject.compose().responseCode, is(expectation.compose().responseCode));
     }


### PR DESCRIPTION
* Allow no more than 10 simultaneous threads.
* Split response building into separate object.
* Do not apply stream manipulation behaviors unless required.
* Move stream manipulation out of ResponseBody into PartialContent.

Most of these changes have a common theme: They're optimizing against an
`ab` test.  In other words, there were some bugs and consistency flaws
which emerged in situations where we were hammering the server with a
ton of concurrent connections.

* When too many threads were being created, we were seeing peer resets.
* We were reading files multiple times per connection.
* Large Response and ResponseBody objects were hiding the multi-read problem.